### PR TITLE
Abstract local test infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install \
+        clean
+
+install:
+	oc create -f local-test-infra/local-partner-pod.yaml
+	oc create -f local-test-infra/local-pod-under-test.yaml
+
+clean:
+	oc delete -f local-test-infra/local-partner-pod.yaml
+	oc delete -f local-test-infra/local-pod-under-test.yaml

--- a/README.md
+++ b/README.md
@@ -1,20 +1,34 @@
 # cnf-certification-test-partner
 
-This repository provides the infrastructure to create a CNF test partner Pod.  The Pod is composed of a single
-container, which is based off Universal Base Image (UBI) 7.  A minimal set of tools is installed on top of the base
-image to fulfill CNF Test dependency requirements:
+This repository contains two major sections:
+* test-partner:  Used on a K8S CNF Certification cluster to verify proper operation of a Vendor's Pod Under Test
+* local-test-infra:  Used to test [test-network-function](https://github.com/redhat-nfvpe/test-network-function) and
+related test suites on a local development machine.  This is infrastructure required for "testing the tester".
+
+## Glossary
+
+* Pod Under Test (PUT): The Vendor Pod, usually provided by a CNF Partner.
+* Test Partner Pod (TPP): A Universal Base Image (UBI) Pod containing the test tools and dependencies to act as a
+traffic workload generator or receiver.  For generic cases, this currently includes ICMPv4 only.
+
+## test-partner
+
+This repository provides the infrastructure to create a CNF test partner Pod, which is used to verify proper operation
+of a Partner Vendor's Pod Under Test in a CNF Certification Cluster.  The Pod is composed of a single container, which
+is based off Universal Base Image (UBI) 7.  A minimal set of tools is installed on top of the base image to fulfill CNF
+Test dependency requirements:
 
 * iputils (for ping)
 * iproute (for ip)
 
-## TODO
+### TODO
 
 * Move to a more centralized container repository instead of relying on rgoulding's development repository.
 * Create an OpenShift Operator for partner.yaml.  This has very little merit for our use-case, but does align with the
   best practices Red Hat recommends.
 * Consider a transition to UBI 8.
 
-## Building the container image
+### Building the container image
 
 In order to build the container image, issue the following command:
 
@@ -28,7 +42,7 @@ In order to push the container image, issue the following command:
 docker push rgoulding/cnf-test-partner
 ```
 
-## Installing the partner pod
+### Installing the partner pod
 
 First, clone this repository:
 
@@ -45,3 +59,36 @@ oc create -f ./partner.yaml
 
 This will create a Pod named "partner" in the default namespace.  This Pod is the test partner for running Generic CNF
 tests.
+
+## local-test-infra
+
+Although any CNF Certification results should be generated using a proper CNF Certification cluster, there are times
+in which using a local emulator can greatly help with test development.  As such, [local-test-infra](./local-test-infra)
+is abstracted to provide a low spec'd PUT and TPP containing the minimial requirements to peform generic test cases.
+These can be used in conjunction with a local kind or minikube cluster to perform local test development.
+
+### local-test-infra Installation using minikube
+
+To start minikube, issue the following command:
+
+```shell script
+minikube start --driver="virtualbox"
+```
+
+To create the PUT and TPP, issue the following command:
+
+```shell script
+make install
+```
+
+This will create a PUT named "test", and a TPP named "partner" which can be used to run generic test suite cases.  Just
+specify [local-test-infra/conf.yaml](./local-test-infra/conf.yaml) to utilize the local environment in conjunction with
+[test-network-function](https://github.com/redhat-nfvpe/test-network-function).
+
+### local-test-infra Un-installation
+
+A utility make target is provided to tear down the local test cluster:
+
+```shell script
+make clean
+```

--- a/local-test-infra/conf.yaml
+++ b/local-test-infra/conf.yaml
@@ -1,0 +1,14 @@
+podUnderTest:
+  name: "test"
+  namespace: "default"
+  containerConfiguration:
+    name: "test"
+    defaultNetworkDevice: "eth0"
+    multusIpAddress: "192.168.2.1"
+partnerPod:
+  name: "partner"
+  namespace: "default"
+  containerConfiguration:
+    name: "partner"
+    defaultNetworkDevice: "eth0"
+    multusIpAddress: "192.168.2.3"

--- a/local-test-infra/local-partner-pod.yaml
+++ b/local-test-infra/local-partner-pod.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: partner
+  name: partner
+spec:
+  containers:
+    - command:
+        - tail
+        - -f
+        - /dev/null
+      image: quay.io/rgoulding/cnf-test-partner:latest
+      name: partner
+      resources:
+        limits:
+          memory: 512Mi
+          cpu: 0.25
+  restartPolicy: Always

--- a/local-test-infra/local-pod-under-test.yaml
+++ b/local-test-infra/local-pod-under-test.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: test
+  name: test
+spec:
+  containers:
+    - command:
+        - tail
+        - -f
+        - /dev/null
+      image: quay.io/rgoulding/cnf-test-partner:latest
+      name: test
+      resources:
+        limits:
+          memory: 512Mi
+          cpu: 0.25
+  restartPolicy: Always

--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi7/ubi:latest
 
-RUN yum install -y iproute iputils
+RUN yum install -y hostname iproute iputils openssh openssh-clients
 
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
Often, when developing for this project, it became useful to have a live setup
to debug against.  This involved committing, pushing a branch to the remote
origin, then checking out on the other side (i.e., the cluster).  It quickly
became apparent that moving our code to New Mexico by way of GitHub was not a
very well thought out solution for tests that do not require real hardware.

This change introduces local test infrastructure to run Pods locally in a dev
environment (such as minikube).  I have not yet tested with Kind, but there
should be no reason that this code wouldn't work with that either.  Running
"make" will produce two local pods (test and partner).  In order to run the
test-network-function CNF Certification suite against this setup, utilize the
configuration in "local-test-infra/conf.yaml".  This may be a useful way to
do "integration" tests in the future, but is certainly too heavyweight to be
applicable to unit tests.