### PR TITLE
Add a proper namespace to the test/partner pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
         clean
 
 install:
+	oc create -f local-test-infra/namespace.yaml
 	oc create -f local-test-infra/local-partner-pod.yaml
 	oc create -f local-test-infra/local-pod-under-test.yaml
 
 clean:
-	oc delete -f local-test-infra/local-partner-pod.yaml
-	oc delete -f local-test-infra/local-pod-under-test.yaml
+	oc delete -f local-test-infra/namespace.yaml

--- a/local-test-infra/local-partner-pod.yaml
+++ b/local-test-infra/local-partner-pod.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: partner
   name: partner
+  namespace: tnf
 spec:
   containers:
     - command:

--- a/local-test-infra/local-pod-under-test.yaml
+++ b/local-test-infra/local-pod-under-test.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: test
   name: test
+  namespace: tnf
 spec:
   containers:
     - command:

--- a/local-test-infra/namespace.yaml
+++ b/local-test-infra/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tnf
+  labels:
+    name: tnf

--- a/test-partner/partner.yaml
+++ b/test-partner/partner.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: partner
   name: partner
+  namespace: tnf
 spec:
   containers:
     - command:
@@ -12,7 +13,7 @@ spec:
         - -f
         - /dev/null
       image: quay.io/testnetworkfunction/cnf-test-partner:latest
-      name: ubi
+      name: partner
       resources:
         limits:
           memory: 1Gi


### PR DESCRIPTION
Adds ability to create "tnf" namespace and installs the test/partner pods in that namespace.

Changes the production container name from "ubi" to "partner" to conform with "local-test-infra" conventions.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>