### PR TITLE
Add CI Tests for test infra and partner image

### DIFF
--- a/.github/actions/start-minikube/action.yaml
+++ b/.github/actions/start-minikube/action.yaml
@@ -1,0 +1,47 @@
+name: start-minikube
+description: Creates and configures a minikube cluster for all things TNF-related
+inputs:
+  minikube_version:
+    default: v1.18.1
+  minikube_driver:
+    default: docker
+  minikube_extra_options:
+    default: '--embed-certs'
+  oc_kcm_timeout:
+    default: 90s
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Download minikube debian package
+      run: |
+        curl -Lo minikube.deb https://storage.googleapis.com/minikube/releases/${{ inputs.minikube_version }}/minikube_latest_amd64.deb
+      shell: bash
+
+    - name: Install minikube
+      run: sudo dpkg -i minikube.deb
+      shell: bash
+
+    - name: Set the default VM driver
+      run: minikube config set vm-driver ${{ inputs.minikube_driver }}
+      shell: bash
+
+    - name: Start the minikube cluster
+      run: minikube start ${{ inputs.minikube_extra_options }}
+      shell: bash
+
+    # The waiting is performed to allow the `kube-controller-manager` to start all required controllers,
+    # such as the `service-account-controller` responsible for managing and creating Service Accounts.
+    - name: Wait for kube-controller-manager
+      run: |
+        echo "Waiting for kube-controller-manager... (timeout: ${{ inputs.oc_kcm_timeout }})" && \
+        oc wait -n kube-system --for=condition=ready pod/kube-controller-manager-minikube --timeout=${{ inputs.oc_kcm_timeout }}
+      shell: bash
+
+    - name: Display kube-system pods
+      run: oc get pods -n kube-system -o wide
+      shell: bash
+
+    - name: Display a friendly summary message
+      run: echo "TNF-compatible minikube cluster is ready to go! Have fun!"
+      shell: bash

--- a/.github/workflows/cnf-test-partner-image.yaml
+++ b/.github/workflows/cnf-test-partner-image.yaml
@@ -1,0 +1,33 @@
+name: 'Test the `cnf-test-partner` image'
+on:
+  push:
+    paths:
+      - 'test-partner/Dockerfile'
+  pull_request:
+defaults:
+  run:
+    shell: bash
+    working-directory: test-partner
+env:
+  IMAGE_NAME: testnetworkfunction/cnf-test-partner
+  IMAGE_TAG: ci-workflow
+
+jobs:
+  test-cnf-test-partner-image:
+    name: 'Build & test the `cnf-test-partner` image'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 'Build the `cnf-test-partner` image'
+        run: docker build --no-cache -f Dockerfile -t $IMAGE_NAME:$IMAGE_TAG .
+
+      - name: 'Test: Check if ping is installed'
+        run: docker run $IMAGE_NAME:$IMAGE_TAG which ping
+
+      - name: 'Test: Check if ip is installed'
+        run: docker run $IMAGE_NAME:$IMAGE_TAG which ip
+
+      - name: 'Test: Check if ssh is installed'
+        run: docker run $IMAGE_NAME:$IMAGE_TAG which ssh

--- a/.github/workflows/local-test-infra.yaml
+++ b/.github/workflows/local-test-infra.yaml
@@ -1,0 +1,63 @@
+name: 'Test the `local-test-infra` config'
+on: [push, pull_request]
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-local-test-infra:
+    name: 'Test the `local-test-infra` configuration on minikube'
+    runs-on: ubuntu-20.04
+    env:
+      TNF_NAMESPACE: tnf
+      PUT_RESOURCE_NAME: test
+      TPP_RESOURCE_NAME: partner
+      DEFAULT_TIMEOUT: 90s
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Start the minikube cluster
+        uses: ./.github/actions/start-minikube
+
+      - name: Create OpenShift resources
+        run: make install
+
+      - name: Set the current context to use the correct TNF namespace
+        run: oc config set-context $(oc config current-context) --namespace=$TNF_NAMESPACE
+
+      # Tests for the test pod (PUT)
+
+      - name: Wait for the test pod to be ready
+        run: oc wait --for=condition=ready pod/$PUT_RESOURCE_NAME --timeout=$DEFAULT_TIMEOUT
+
+      - name: '(test pod) Test: Check if ping is installed'
+        run: oc exec -i $PUT_RESOURCE_NAME -c $PUT_RESOURCE_NAME -- which ping
+
+      - name: '(test pod) Test: Check if ip is installed'
+        run: oc exec -i $PUT_RESOURCE_NAME -c $PUT_RESOURCE_NAME -- which ip
+
+      - name: '(test pod) Test: Check if ssh is installed'
+        run: oc exec -i $PUT_RESOURCE_NAME -c $PUT_RESOURCE_NAME -- which ssh
+
+      # Tests for the partner pod (TPP)
+
+      - name: Wait for the partner pod to be ready
+        run: oc wait --for=condition=ready pod/$TPP_RESOURCE_NAME --timeout=$DEFAULT_TIMEOUT
+
+      - name: '(partner pod) Test: Check if ping is installed'
+        run: oc exec -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ping
+
+      - name: '(partner pod) Test: Check if ip is installed'
+        run: oc exec -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ip
+
+      - name: '(partner pod) Test: Check if ssh is installed'
+        run: oc exec -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ssh
+
+      # Cleanup
+
+      - name: Delete OpenShift resources
+        run: make clean
+
+      - name: 'Test: Check if `make clean` removed all TNF pods'
+        run: '[[ "$(oc get pods -o name | wc -l)" -eq "0" ]]'

--- a/.github/workflows/partner-pod.yaml
+++ b/.github/workflows/partner-pod.yaml
@@ -1,0 +1,41 @@
+name: Test the partner pod installation
+on: [push, pull_request]
+defaults:
+  run:
+    shell: bash
+    working-directory: test-partner
+
+jobs:
+  test-local-test-infra:
+    name: 'Test the partner pod on minikube'
+    runs-on: ubuntu-20.04
+    env:
+      TNF_NAMESPACE: tnf
+      TPP_RESOURCE_NAME: partner
+      DEFAULT_TIMEOUT: 90s
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Start the minikube cluster
+        uses: ./.github/actions/start-minikube
+
+      - name: Add a proper label to the minikube node
+        run: oc label nodes minikube role=partner
+
+      - name: Create the partner pod using the instructions in the README
+        run: |
+          oc create -f ./namespace.yaml
+          oc create -f ./partner.yaml
+
+      - name: Wait for the partner pod to be ready
+        run: oc wait -n $TNF_NAMESPACE --for=condition=ready pod/$TPP_RESOURCE_NAME --timeout=$DEFAULT_TIMEOUT
+
+      - name: '(partner pod) Test: Check if ping is installed'
+        run: oc exec -n $TNF_NAMESPACE -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ping
+
+      - name: '(partner pod) Test: Check if ip is installed'
+        run: oc exec -n $TNF_NAMESPACE -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ip
+
+      - name: '(partner pod) Test: Check if ssh is installed'
+        run: oc exec -n $TNF_NAMESPACE -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ssh


### PR DESCRIPTION
Implements three new GitHub Workflows for testing, and a GitHub Action for setting up a minikube cluster suitable for CI/CD pipelines.

The new `start-minikube` GitHub Action should be considered as the recommended Action for creating test clusters for TNF resources in CI workflows, removing the dependency on third-party, untrusted Actions from the GitHub Marketplace.

The new workflows are:

- `cnf-test-partner-image.yaml`: Tests whether the partner image can be built, and whether the image contains all required tools.

- `local-test-infra.yaml`: Tests the OpenShift resources defined in the local-test-infra directory.
  The resources are created on the minikube test cluster using commands exposed in the Makefile.

- `partner-pod.yaml`: Tests the installation process of the partner pod according to the instructions in the README. 
  The pod is created on the minikube test cluster.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>