### PR TITLE
Extend the CI workflow with image push to Quay.io

### DIFF
--- a/.github/workflows/cnf-test-partner-image.yaml
+++ b/.github/workflows/cnf-test-partner-image.yaml
@@ -1,4 +1,4 @@
-name: 'Test the `cnf-test-partner` image'
+name: 'Test/push the `cnf-test-partner` image'
 on:
   push:
     paths:
@@ -9,12 +9,14 @@ defaults:
     shell: bash
     working-directory: test-partner
 env:
+  REGISTRY: quay.io
   IMAGE_NAME: testnetworkfunction/cnf-test-partner
-  IMAGE_TAG: ci-workflow
+  IMAGE_TAG: latest
+  IMAGE_CONTAINER_FILE_PATH: test-partner/Dockerfile
 
 jobs:
   test-cnf-test-partner-image:
-    name: 'Build & test the `cnf-test-partner` image'
+    name: 'Build and test the `cnf-test-partner` image'
     runs-on: ubuntu-20.04
 
     steps:
@@ -31,3 +33,31 @@ jobs:
 
       - name: 'Test: Check if ssh is installed'
         run: docker run $IMAGE_NAME:$IMAGE_TAG which ssh
+
+  push-cnf-test-partner-image:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    name: 'Push the new `cnf-test-partner` image to Quay.io'
+    needs: test-cnf-test-partner-image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout the main branch
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Authenticate against Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          # Use a Robot Account to authenticate against Quay.io
+          # https://docs.quay.io/glossary/robot-accounts.html
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: 'Build and push the new `cnf-test-partner` image'
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: ${{ env.IMAGE_CONTAINER_FILE_PATH }}
+          tags: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}'


### PR DESCRIPTION
Introduces a push job to the `cnf-test-partner-image.yaml` workflow.
The new job is dependent on the successful completion of an already existing job, responsible for building and testing the image.

The image pushed to Quay.io is always built from the `main` branch.

This change extends a CI workflow introduced in CTONET-831.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>

---

*Note 1*: The _push job_ requires two secrets: `QUAY_ROBOT_USERNAME` and `QUAY_ROBOT_TOKEN`. Read the [Quay.io Robot Accounts](https://docs.quay.io/glossary/robot-accounts.html) page to learn how to generate these credentials. 

*Note 2*: Secrets defined in the main repository cannot be accessed by workflows added in PRs initialized from forked repositories.

*Note 3*: This change is dependent on CTONET-831, PR #10. A rebase will be required.