### PR TITLE
Replace Pod definitions with Deployments

### DIFF
--- a/local-test-infra/local-partner-pod.yaml
+++ b/local-test-infra/local-partner-pod.yaml
@@ -1,24 +1,31 @@
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  labels:
-    app: partner
-    test-network-function.com/generic: orchestrator
-  annotations:
-    test-network-function.com/defaultnetworkinterface: '"eth0"' # optional
   name: partner
   namespace: tnf
 spec:
-  containers:
-    - command:
-        - tail
-        - -f
-        - /dev/null
-      image: quay.io/testnetworkfunction/cnf-test-partner:latest
+  replicas: 1
+  selector:
+    matchLabels:
+      app: partner
+  template:
+    metadata:
+      labels:
+        app: partner
+        test-network-function.com/generic: orchestrator
+      annotations:
+        test-network-function.com/defaultnetworkinterface: '"eth0"' # optional
       name: partner
-      resources:
-        limits:
-          memory: 512Mi
-          cpu: 0.25
-  restartPolicy: Always
+    spec:
+      containers:
+        - command:
+            - tail
+            - -f
+            - /dev/null
+          image: quay.io/testnetworkfunction/cnf-test-partner:latest
+          name: partner
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 0.25

--- a/local-test-infra/local-pod-under-test.yaml
+++ b/local-test-infra/local-pod-under-test.yaml
@@ -1,26 +1,33 @@
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  labels:
-    app: test
-    test-network-function.com/generic: target
-    test-network-function.com/container: target
-  annotations:
-    test-network-function.com/container_tests: '["PRIVILEGED_POD","PRIVILEGED_ROLE"]' # optional
-    test-network-function.com/defaultnetworkinterface: '"eth0"' # optional
   name: test
   namespace: tnf
 spec:
-  containers:
-    - command:
-        - tail
-        - -f
-        - /dev/null
-      image: quay.io/testnetworkfunction/cnf-test-partner:latest
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+        test-network-function.com/generic: target
+        test-network-function.com/container: target
+      annotations:
+        test-network-function.com/container_tests: '["PRIVILEGED_POD","PRIVILEGED_ROLE"]' # optional
+        test-network-function.com/defaultnetworkinterface: '"eth0"' # optional
       name: test
-      resources:
-        limits:
-          memory: 512Mi
-          cpu: 0.25
-  restartPolicy: Always
+    spec:
+      containers:
+        - command:
+            - tail
+            - -f
+            - /dev/null
+          image: quay.io/testnetworkfunction/cnf-test-partner:latest
+          name: test
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 0.25

--- a/test-partner/partner.yaml
+++ b/test-partner/partner.yaml
@@ -1,23 +1,30 @@
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  labels:
-    app: partner
   name: partner
   namespace: tnf
 spec:
-  containers:
-    - command:
-        - tail
-        - -f
-        - /dev/null
-      image: quay.io/testnetworkfunction/cnf-test-partner:latest
+  replicas: 1
+  selector:
+    matchLabels:
+      app: partner
+  template:
+    metadata:
+      labels:
+        app: partner
       name: partner
-      resources:
-        limits:
-          memory: 1Gi
-          cpu: 1
-  restartPolicy: Always
-  nodeSelector:
-    role: partner
+    spec:
+      containers:
+        - command:
+            - tail
+            - -f
+            - /dev/null
+          image: quay.io/testnetworkfunction/cnf-test-partner:latest
+          name: partner
+          resources:
+            limits:
+              memory: 1Gi
+              cpu: 1
+      nodeSelector:
+        role: partner


### PR DESCRIPTION
The `restartPolicy` field was removed from the template spec because Deployments render this field redundant.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>