### PR TITLE
Update CI workflows to auto-discover Pod names

### DIFF
--- a/.github/actions/create-local-test-infra-resources/action.yaml
+++ b/.github/actions/create-local-test-infra-resources/action.yaml
@@ -6,11 +6,20 @@ inputs:
   oc_namespace:
     default: tnf
   oc_pod_timeout:
+    description: "Timeout for the `oc wait` command"
     default: 90s
-  put_resource_name:
+  put_pod_label_app:
+    description: "The expected value of the test pod's `app` label"
     default: test
-  tpp_resource_name:
+  put_pod_name_env_var:
+    description: "The environment variable the test pod's name will be saved to"
+    default: PUT_POD_NAME
+  tpp_pod_label_app:
+    description: "The expected value of the partner pod's `app` label"
     default: partner
+  tpp_pod_name_env_var:
+    description: "The environment variable the partner pod's name will be saved to"
+    default: TPP_POD_NAME
 
 runs:
   using: 'composite'
@@ -24,10 +33,36 @@ runs:
       run: oc config set-context $(oc config current-context) --namespace=${{ inputs.oc_namespace }}
       shell: bash
 
-    - name: Wait for the test pod (PUT) to be ready
-      run: oc wait --for=condition=ready pod/${{ inputs.put_resource_name }} --timeout=${{ inputs.oc_pod_timeout }}
+    - name: (PUT) Ensure only one pod with the label is present
+      run: '[[ $(oc get pods -l "app=${{ inputs.put_pod_label_app }}" -o name | wc -l) -eq "1" ]]'
       shell: bash
 
-    - name: Wait for the partner pod (TPP) to be ready
-      run: oc wait --for=condition=ready pod/${{ inputs.tpp_resource_name }} --timeout=${{ inputs.oc_pod_timeout }}
+    - name: (TPP) Ensure only one pod with the label is present
+      run: '[[ $(oc get pods -l "app=${{ inputs.tpp_pod_label_app }}" -o name | wc -l) -eq "1" ]]'
+      shell: bash
+
+    - name: (PUT) Discover the name of the test pod
+      run: |
+        PUT_POD_NAME=$(oc get pods -l 'app=${{ inputs.put_pod_label_app }}' -o jsonpath='{.items[0].metadata.name}')
+        echo "${{ inputs.put_pod_name_env_var }}=$PUT_POD_NAME" >> $GITHUB_ENV
+      shell: bash
+
+    - name: (TPP) Discover the name of the partner pod
+      run: |
+        TPP_POD_NAME=$(oc get pods -l 'app=${{ inputs.tpp_pod_label_app }}' -o jsonpath='{.items[0].metadata.name}')
+        echo "${{ inputs.tpp_pod_name_env_var }}=$TPP_POD_NAME" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Display auto-discovered pod names
+      run: |
+        echo "(PUT) test pod name: $${{ inputs.put_pod_name_env_var }}"
+        echo "(TPP) partner pod name: $${{ inputs.tpp_pod_name_env_var }}"
+      shell: bash
+
+    - name: (PUT) Wait for the test pod to be ready
+      run: oc wait --for=condition=ready pod/$${{ inputs.put_pod_name_env_var }} --timeout=${{ inputs.oc_pod_timeout }}
+      shell: bash
+
+    - name: (TPP) Wait for the partner pod to be ready
+      run: oc wait --for=condition=ready pod/$${{ inputs.tpp_pod_name_env_var }} --timeout=${{ inputs.oc_pod_timeout }}
       shell: bash

--- a/.github/workflows/local-test-infra.yaml
+++ b/.github/workflows/local-test-infra.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TNF_NAMESPACE: tnf
-      PUT_RESOURCE_NAME: test
-      TPP_RESOURCE_NAME: partner
+      PUT_CONTAINER_NAME: test
+      TPP_CONTAINER_NAME: partner
       DEFAULT_TIMEOUT: 90s
 
     steps:
@@ -23,27 +23,30 @@ jobs:
       - name: Create `local-test-infra` OpenShift resources
         uses: ./.github/actions/create-local-test-infra-resources
 
+      # $PUT_POD_NAME and $TPP_POD_NAME environment variables are set
+      # during the execution of `create-local-test-infra-resources`
+
       # Tests for the test pod (PUT)
 
       - name: '(test pod) Test: Check if ping is installed'
-        run: oc exec -i $PUT_RESOURCE_NAME -c $PUT_RESOURCE_NAME -- which ping
+        run: oc exec -i $PUT_POD_NAME -c $PUT_CONTAINER_NAME -- which ping
 
       - name: '(test pod) Test: Check if ip is installed'
-        run: oc exec -i $PUT_RESOURCE_NAME -c $PUT_RESOURCE_NAME -- which ip
+        run: oc exec -i $PUT_POD_NAME -c $PUT_CONTAINER_NAME -- which ip
 
       - name: '(test pod) Test: Check if ssh is installed'
-        run: oc exec -i $PUT_RESOURCE_NAME -c $PUT_RESOURCE_NAME -- which ssh
+        run: oc exec -i $PUT_POD_NAME -c $PUT_CONTAINER_NAME -- which ssh
 
       # Tests for the partner pod (TPP)
 
       - name: '(partner pod) Test: Check if ping is installed'
-        run: oc exec -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ping
+        run: oc exec -i $TPP_POD_NAME -c $TPP_CONTAINER_NAME -- which ping
 
       - name: '(partner pod) Test: Check if ip is installed'
-        run: oc exec -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ip
+        run: oc exec -i $TPP_POD_NAME -c $TPP_CONTAINER_NAME -- which ip
 
       - name: '(partner pod) Test: Check if ssh is installed'
-        run: oc exec -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ssh
+        run: oc exec -i $TPP_POD_NAME -c $TPP_CONTAINER_NAME -- which ssh
 
       # Cleanup
 

--- a/.github/workflows/partner-pod.yaml
+++ b/.github/workflows/partner-pod.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TNF_NAMESPACE: tnf
-      TPP_RESOURCE_NAME: partner
+      TPP_CONTAINER_NAME: partner
       DEFAULT_TIMEOUT: 90s
 
     steps:
@@ -28,14 +28,21 @@ jobs:
           oc create -f ./namespace.yaml
           oc create -f ./partner.yaml
 
+      - name: Ensure only one partner pod with the label is present
+        run: '[[ $(oc get pods -n $TNF_NAMESPACE -l "app=partner" -o name | wc -l) -eq "1" ]]'
+
+      - name: Discover the name of the partner pod
+        run: |
+          echo "TPP_POD_NAME=$(oc get pods -n $TNF_NAMESPACE -l 'app=partner' -o jsonpath='{.items[0].metadata.name}')" >> $GITHUB_ENV
+
       - name: Wait for the partner pod to be ready
-        run: oc wait -n $TNF_NAMESPACE --for=condition=ready pod/$TPP_RESOURCE_NAME --timeout=$DEFAULT_TIMEOUT
+        run: oc wait -n $TNF_NAMESPACE --for=condition=ready pod/$TPP_POD_NAME --timeout=$DEFAULT_TIMEOUT
 
       - name: '(partner pod) Test: Check if ping is installed'
-        run: oc exec -n $TNF_NAMESPACE -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ping
+        run: oc exec -n $TNF_NAMESPACE -i $TPP_POD_NAME -c $TPP_CONTAINER_NAME -- which ping
 
       - name: '(partner pod) Test: Check if ip is installed'
-        run: oc exec -n $TNF_NAMESPACE -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ip
+        run: oc exec -n $TNF_NAMESPACE -i $TPP_POD_NAME -c $TPP_CONTAINER_NAME -- which ip
 
       - name: '(partner pod) Test: Check if ssh is installed'
-        run: oc exec -n $TNF_NAMESPACE -i $TPP_RESOURCE_NAME -c $TPP_RESOURCE_NAME -- which ssh
+        run: oc exec -n $TNF_NAMESPACE -i $TPP_POD_NAME -c $TPP_CONTAINER_NAME -- which ssh


### PR DESCRIPTION
Extends the `create-local-test-infra-resources` action with auto-discovery for test and partner pods' names fetched by querying for available resources with a properly defined `app` label.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>