### PR TITLE
Fix local-test-infra GitHub Action race condition

### DIFF
--- a/.github/actions/create-local-test-infra-resources/action.yaml
+++ b/.github/actions/create-local-test-infra-resources/action.yaml
@@ -33,6 +33,14 @@ runs:
       run: oc config set-context $(oc config current-context) --namespace=${{ inputs.oc_namespace }}
       shell: bash
 
+    - name: (PUT) Wait for the test pod to be ready
+      run: oc wait pod --for=condition=ready -l "app=${{ inputs.put_pod_label_app }}" --timeout=${{ inputs.oc_pod_timeout }}
+      shell: bash
+
+    - name: (TPP) Wait for the partner pod to be ready
+      run: oc wait pod --for=condition=ready -l "app=${{ inputs.tpp_pod_label_app }}" --timeout=${{ inputs.oc_pod_timeout }}
+      shell: bash
+
     - name: (PUT) Ensure only one pod with the label is present
       run: '[[ $(oc get pods -l "app=${{ inputs.put_pod_label_app }}" -o name | wc -l) -eq "1" ]]'
       shell: bash
@@ -57,12 +65,4 @@ runs:
       run: |
         echo "(PUT) test pod name: $${{ inputs.put_pod_name_env_var }}"
         echo "(TPP) partner pod name: $${{ inputs.tpp_pod_name_env_var }}"
-      shell: bash
-
-    - name: (PUT) Wait for the test pod to be ready
-      run: oc wait --for=condition=ready pod/$${{ inputs.put_pod_name_env_var }} --timeout=${{ inputs.oc_pod_timeout }}
-      shell: bash
-
-    - name: (TPP) Wait for the partner pod to be ready
-      run: oc wait --for=condition=ready pod/$${{ inputs.tpp_pod_name_env_var }} --timeout=${{ inputs.oc_pod_timeout }}
       shell: bash

--- a/.github/workflows/partner-pod.yaml
+++ b/.github/workflows/partner-pod.yaml
@@ -28,15 +28,15 @@ jobs:
           oc create -f ./namespace.yaml
           oc create -f ./partner.yaml
 
+      - name: Wait for the partner pod to be ready
+        run: oc wait pod -n $TNF_NAMESPACE --for=condition=ready -l 'app=partner' --timeout=$DEFAULT_TIMEOUT
+
       - name: Ensure only one partner pod with the label is present
         run: '[[ $(oc get pods -n $TNF_NAMESPACE -l "app=partner" -o name | wc -l) -eq "1" ]]'
 
       - name: Discover the name of the partner pod
         run: |
           echo "TPP_POD_NAME=$(oc get pods -n $TNF_NAMESPACE -l 'app=partner' -o jsonpath='{.items[0].metadata.name}')" >> $GITHUB_ENV
-
-      - name: Wait for the partner pod to be ready
-        run: oc wait -n $TNF_NAMESPACE --for=condition=ready pod/$TPP_POD_NAME --timeout=$DEFAULT_TIMEOUT
 
       - name: '(partner pod) Test: Check if ping is installed'
         run: oc exec -n $TNF_NAMESPACE -i $TPP_POD_NAME -c $TPP_CONTAINER_NAME -- which ping


### PR DESCRIPTION
The Action would fail when attempting to auto-discover a name of a pod
that had not yet been scheduled to a node.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>