### PR TITLE
Increase timeout of the `oc wait` command

### DIFF
--- a/.github/actions/start-minikube/action.yaml
+++ b/.github/actions/start-minikube/action.yaml
@@ -8,7 +8,7 @@ inputs:
   minikube_extra_options:
     default: '--embed-certs'
   oc_kcm_timeout:
-    default: 90s
+    default: 5m
 
 runs:
   using: 'composite'


### PR DESCRIPTION
This changes the timeout of the `oc wait` command from 90 seconds to 5
minutes. The `oc wait` command waits for `kube-controller-manager` to be
ready in the cluster.