### PR TITLE
Remove kube-api-access volume from debug partner pod

### DIFF
--- a/test-partner/debugpartner.yaml
+++ b/test-partner/debugpartner.yaml
@@ -38,9 +38,6 @@ spec:
           volumeMounts:
             - mountPath: /host
               name: host
-            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-              name: kube-api-access-whppm
-              readOnly: true
       enableServiceLinks: true
       hostNetwork: true
       hostPID: true
@@ -51,6 +48,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
+      automountServiceAccountToken: true
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoExecute
@@ -68,26 +66,3 @@ spec:
             path: /
             type: Directory
           name: host
-        - name: kube-api-access-whppm
-          projected:
-            defaultMode: 420
-            sources:
-              - serviceAccountToken:
-                  expirationSeconds: 3607
-                  path: token
-              - configMap:
-                  items:
-                    - key: ca.crt
-                      path: ca.crt
-                  name: kube-root-ca.crt
-              - downwardAPI:
-                  items:
-                    - fieldRef:
-                        apiVersion: v1
-                        fieldPath: metadata.namespace
-                      path: namespace
-              - configMap:
-                  items:
-                    - key: service-ca.crt
-                      path: service-ca.crt
-                  name: openshift-service-ca.crt

--- a/test-partner/debugpartner.yaml
+++ b/test-partner/debugpartner.yaml
@@ -48,7 +48,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      automountServiceAccountToken: true
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoExecute


### PR DESCRIPTION
This volume is automatically added by OpenShift, and its definition
varies between Openshift >= 4.7, which uses RootCAConfigMap [1], and
previous versions, which use the default namespace service account.

[1] - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#introducing-rootcaconfigmap