### PR TITLE
Replace support-tools image with custom one

### DIFF
--- a/.github/workflows/debug-partner-image.yaml
+++ b/.github/workflows/debug-partner-image.yaml
@@ -1,0 +1,63 @@
+name: 'Test/push the `debug-partner` image'
+on:
+  push:
+    paths:
+      - 'test-partner/Dockerfile.debug-partner'
+  pull_request:
+defaults:
+  run:
+    shell: bash
+    working-directory: test-partner
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: testnetworkfunction/debug-partner
+  IMAGE_TAG: latest
+  IMAGE_CONTAINER_FILE_PATH: test-partner/Dockerfile.debug-partner
+
+jobs:
+  test-debug-partner-image:
+    name: 'Build and test the `debug-partner` image'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 'Build the `debug-partner` image'
+        run: docker build --no-cache -f Dockerfile.debug-partner -t $IMAGE_NAME:$IMAGE_TAG .
+
+      - name: 'Test: Check if lscpu is installed'
+        run: docker run $IMAGE_NAME:$IMAGE_TAG which lscpu
+
+      - name: 'Test: Check if lsblk is installed'
+        run: docker run $IMAGE_NAME:$IMAGE_TAG which lsblk
+
+      - name: 'Test: Check if lspci is installed'
+        run: docker run $IMAGE_NAME:$IMAGE_TAG which lspci
+
+  push-debug-partner-image:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    name: 'Push the new `debug-partner` image to Quay.io'
+    needs: test-debug-partner-image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout the main branch
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Authenticate against Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          # Use a Robot Account to authenticate against Quay.io
+          # https://docs.quay.io/glossary/robot-accounts.html
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: 'Build and push the new `debug-partner` image'
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: ${{ env.IMAGE_CONTAINER_FILE_PATH }}
+          tags: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Together, they make up the basic infrastructure required for "testing the tester
 * Pod Under Test (PUT): The Vendor Pod, usually provided by a CNF Partner.
 * Operator Under Test (OT): The Vendor Operator, usually provided by a CNF Partner.
 * Test Partner Pod (TPP): A Universal Base Image (UBI) Pod containing the test tools and dependencies to act as a traffic workload generator or receiver.  For generic cases, this currently includes ICMPv4 only.
-* Debug Pod (DP): A Pod running [RHEL support tool image](https://catalog.redhat.com/software/containers/rhel8/support-tools/5ba3eaf9bed8bd6ee819b78b) deployed as part of a daemon set for accessing node information. DPs is deployed in "default" namespace
+* Debug Pod (DP): A Pod running [a UBI8-based support image](https://quay.io/repository/testnetworkfunction/debug-partner) deployed as part of a daemon set for accessing node information. DPs is deployed in "default" namespace
 * CRD Under Test (CRD): A basic CustomResourceDefinition.
 
 

--- a/scripts/deploy-debug-ds.sh
+++ b/scripts/deploy-debug-ds.sh
@@ -4,16 +4,12 @@
 SCRIPT_DIR=$(dirname "$0")
 source $SCRIPT_DIR/init-env.sh
 
-export REDHAT_RHEL_REGISTRY="${REDHAT_RHEL_REGISTRY:-registry.redhat.io/rhel8}"
+export REDHAT_RHEL_REGISTRY="${REDHAT_RHEL_REGISTRY:-quay.io/testnetworkfunction}"
+export SUPPORT_IMAGE="${SUPPORT_IMAGE:-debug-partner:latest}"
 # check if we're using minikube by looking for kube-apiserver-minikube pod
 # if it's minikube, don't install debug partner
-if $TNF_NON_OCP_CLUSTER
-then
-  echo "minikube detected, skip installing debug daemonSet"
-else
-  echo "use registry $REDHAT_RHEL_REGISTRY"
-  mkdir -p ./temp
-  cat ./test-partner/debugpartner.yaml | $SCRIPT_DIR/mo > ./temp/debugpartner.yaml
-  oc apply -f ./temp/debugpartner.yaml
-  rm ./temp/debugpartner.yaml
-fi
+echo "use registry $REDHAT_RHEL_REGISTRY"
+mkdir -p ./temp
+cat ./test-partner/debugpartner.yaml | $SCRIPT_DIR/mo > ./temp/debugpartner.yaml
+oc apply -f ./temp/debugpartner.yaml
+rm ./temp/debugpartner.yaml

--- a/scripts/deploy-debug-ds.sh
+++ b/scripts/deploy-debug-ds.sh
@@ -4,11 +4,10 @@
 SCRIPT_DIR=$(dirname "$0")
 source $SCRIPT_DIR/init-env.sh
 
-export REDHAT_RHEL_REGISTRY="${REDHAT_RHEL_REGISTRY:-quay.io/testnetworkfunction}"
 export SUPPORT_IMAGE="${SUPPORT_IMAGE:-debug-partner:latest}"
 # check if we're using minikube by looking for kube-apiserver-minikube pod
 # if it's minikube, don't install debug partner
-echo "use registry $REDHAT_RHEL_REGISTRY"
+echo "using registry $TNF_PARTNER_REPO"
 mkdir -p ./temp
 cat ./test-partner/debugpartner.yaml | $SCRIPT_DIR/mo > ./temp/debugpartner.yaml
 oc apply -f ./temp/debugpartner.yaml

--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+RUN \
+    yum -y install pciutils util-linux net-tools && \
+    yum -y update && \
+    yum clean all -y && \
+    rm -rf /var/cache/yum
+
+VOLUME ["/host"]

--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 
 RUN \
     yum -y update && \
-    yum -y install pciutils util-linux net-tools && \
+    yum -y install pciutils util-linux net-tools procps-ng && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 

--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -1,8 +1,8 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
 RUN \
-    yum -y install pciutils util-linux net-tools && \
     yum -y update && \
+    yum -y install pciutils util-linux net-tools && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 

--- a/test-partner/debugpartner.yaml
+++ b/test-partner/debugpartner.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - command:
             - /bin/sh
-          image: "{{REDHAT_RHEL_REGISTRY}}/{{SUPPORT_IMAGE}}"
+          image: "{{TNF_PARTNER_REPO}}/{{SUPPORT_IMAGE}}"
           imagePullPolicy: IfNotPresent
           name: container-00
           resources: {}

--- a/test-partner/debugpartner.yaml
+++ b/test-partner/debugpartner.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - command:
             - /bin/sh
-          image: "{{REDHAT_RHEL_REGISTRY}}/support-tools:latest"
+          image: "{{REDHAT_RHEL_REGISTRY}}/{{SUPPORT_IMAGE}}"
           imagePullPolicy: IfNotPresent
           name: container-00
           resources: {}


### PR DESCRIPTION
Using the support-tools image for debug partner pods restricts us to
OpenShift environments in some tests, like diagnostic. We can swap that
one with a UBI8-based image, so those tests can be executed on minikube
or other environments as well.