### PR TITLE
Add psmisc package to cnf-test-partner image

### DIFF
--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
-RUN yum install -y hostname iproute iputils openssh openssh-clients podman
+RUN yum install -y hostname iproute iputils openssh openssh-clients podman psmisc
 
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
We are using the killall command in the local-pod-under-test deployment
[1], and not having the binary is raising some warnings during
execution.

[1] - https://github.com/test-network-function/cnf-certification-test-partner/blob/main/test-target/local-pod-under-test.yaml#L40