### PR TITLE
Add jq to debug partner image

### DIFF
--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 
 RUN \
     yum -y update && \
-    yum -y install pciutils util-linux net-tools procps-ng iputils iproute && \
+    yum -y install pciutils util-linux net-tools procps-ng iputils iproute jq && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
This is required by some diagnostic tests, and it is better not to relay
on the utility being present on the k8s node.