### PR TITLE
Add olm install wait and pin OLM version to prevent regression

### DIFF
--- a/scripts/deploy-operator.sh
+++ b/scripts/deploy-operator.sh
@@ -33,3 +33,13 @@ operator-sdk run bundle $OPERATOR_BUNDLE_IMAGE_FULL_NAME -n $TNF_EXAMPLE_CNF_NAM
 # If short name "csv" is used, the call will fail the first time 
 # With long name the first time it will work and subsequent time it will work with long or short names 
 oc get clusterserviceversions.operators.coreos.com -n $TNF_EXAMPLE_CNF_NAMESPACE
+
+CSV_MATCH=$(oc get csv -n $TNF_EXAMPLE_CNF_NAMESPACE -ogo-template='{{ range .items}}{{.metadata.name}}{{end}}' 2>/dev/null | grep "nginx-operator.v0.0.1")
+if [ "$CSV_MATCH" = "nginx-operator.v0.0.1" ];
+then
+  echo "CSV successfully deployed"
+else
+  echo "ERROR: CSV not deployed. Operator deployment failed -- interrupting tests"
+  exit 1
+fi
+

--- a/scripts/deploy-operator.sh
+++ b/scripts/deploy-operator.sh
@@ -29,12 +29,10 @@ fi
 # Deploy the operator bundle
 operator-sdk run bundle $OPERATOR_BUNDLE_IMAGE_FULL_NAME -n $TNF_EXAMPLE_CNF_NAMESPACE $ADD_SECRET
 
-# Important: this line is required to enable csv short names with minikube
+# Important: this line (output of command is now captured) is required to enable csv short names with minikube
 # If short name "csv" is used, the call will fail the first time 
 # With long name the first time it will work and subsequent time it will work with long or short names 
-oc get clusterserviceversions.operators.coreos.com -n $TNF_EXAMPLE_CNF_NAMESPACE
-
-CSV_MATCH=$(oc get csv -n $TNF_EXAMPLE_CNF_NAMESPACE -ogo-template='{{ range .items}}{{.metadata.name}}{{end}}' 2>/dev/null | grep "nginx-operator.v0.0.1")
+CSV_MATCH=$(oc get clusterserviceversions.operators.coreos.com -n $TNF_EXAMPLE_CNF_NAMESPACE -ogo-template='{{ range .items}}{{.metadata.name}}{{end}}' 2>/dev/null | grep "nginx-operator.v0.0.1")
 if [ "$CSV_MATCH" = "nginx-operator.v0.0.1" ];
 then
   echo "CSV successfully deployed"

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -6,7 +6,7 @@ source $SCRIPT_DIR/init-env.sh
 
 # Install OLM
 operator-sdk olm uninstall
-operator-sdk olm install
+operator-sdk olm install --version=v0.18.3
 # Wait for all OLM pods to be ready
 kubectl wait --for=condition=ready pod --all=true -nolm --timeout=$TNF_DEPLOYMENT_TIMEOUT
 sleep 5s

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-set -x
+
+# Initialization
+SCRIPT_DIR=$(dirname "$0")
+source $SCRIPT_DIR/init-env.sh
 
 # Install OLM
 operator-sdk olm uninstall
 operator-sdk olm install
+# Wait for all OLM pods to be ready
+kubectl wait --for=condition=ready pod --all=true -nolm --timeout=$TNF_DEPLOYMENT_TIMEOUT
+sleep 5s

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -16,7 +16,7 @@ else
   export OS="$(uname | awk '{print tolower($0)}')"
 
   ## Download executable
-  export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.11.0
+  export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0
   curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
 
   ## Download the auth key


### PR DESCRIPTION
I tried to add several delays which helped but after many long retests (and being blocked with docker pull limit), it sometimes failed
The root cause in the end seems to be the OLM version which is currently set to use the latest. See below
https://github.com/operator-framework/operator-lifecycle-manager/issues/2454

Still testing it but it might be good now
Added this:
- condition to way for OLM pods to be fully ready
- wait 5s after that
- upgrade the operator-sdk version 
- pin the version of OLM to v0.18.3
- make the operator install fail if a proper CSV is not present
