### PR TITLE
Update Go to 1.17.6

### DIFF
--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -4,7 +4,7 @@ RUN yum install -y wget make hostname iproute iputils openssh openssh-clients po
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.17.4.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.17.6.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \


### PR DESCRIPTION
Go 1.17.6 is now available.

https://twitter.com/golang/status/1479199301352013829

From their release page:
```
go1.17.6 (released 2022-01-06) includes fixes to the compiler, linker, runtime, and the crypto/x509, net/http, and reflect packages. See the Go 1.17.6 milestone on our issue tracker for details.
```