### PR TITLE
Always-on debug pods support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ By default, DP are deployed in "default" namespace. all the other deployment fil
 ```shell-script
 export TNF_EXAMPLE_CNF_NAMESPACE="tnf" #tnf for example
 ```
+
+## On-demand vx always on debug pods
+By default debug pods are installed on demand when the tnf test suite is deployed. To deploy debug pods on all nodes in the cluster, configure the following environment variable:
+```shell-script
+export ON_DEMAND_DEBUG_PODS=false
+```
 ## Cloning the repository
 
 The repository can be cloned to local machine using:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ By default, DP are deployed in "default" namespace. all the other deployment fil
 export TNF_EXAMPLE_CNF_NAMESPACE="tnf" #tnf for example
 ```
 
-## On-demand vx always on debug pods
+## On-demand vs always on debug pods
 By default debug pods are installed on demand when the tnf test suite is deployed. To deploy debug pods on all nodes in the cluster, configure the following environment variable:
 ```shell-script
 export ON_DEMAND_DEBUG_PODS=false

--- a/scripts/deploy-debug-ds.sh
+++ b/scripts/deploy-debug-ds.sh
@@ -15,7 +15,8 @@ then
   NODE_SELECTOR=""
 else
   echo "Configuring on-demand debug pods"
-  NODE_SELECTOR="nodeSelector:
+  NODE_SELECTOR="
+      nodeSelector:
         test-network-function.com/node: target"
 fi
 

--- a/scripts/deploy-debug-ds.sh
+++ b/scripts/deploy-debug-ds.sh
@@ -8,6 +8,17 @@ export SUPPORT_IMAGE="${SUPPORT_IMAGE:-debug-partner:latest}"
 
 echo "using registry $TNF_PARTNER_REPO"
 mkdir -p ./temp
-cat ./test-partner/debugpartner.yaml | $SCRIPT_DIR/mo > ./temp/debugpartner.yaml
+
+if [ "$ON_DEMAND_DEBUG_PODS" = "false" ];
+then
+  echo "configuring always-on debug pods"
+  NODE_SELECTOR=""
+else
+  echo "Configuring on-demand debug pods"
+  NODE_SELECTOR="nodeSelector:
+        test-network-function.com/node: target"
+fi
+
+cat ./test-partner/debugpartner.yaml | NODE_SELECTOR=$NODE_SELECTOR $SCRIPT_DIR/mo > ./temp/debugpartner.yaml
 oc apply -f ./temp/debugpartner.yaml
 rm ./temp/debugpartner.yaml

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -32,6 +32,9 @@ oc create namespace ${TNF_EXAMPLE_CNF_NAMESPACE} 2>/dev/null
 # Default Namespace
 export DEFAULT_NAMESPACE="${DEFAULT_NAMESPACE:-default}"
 
+# Debug on-demand by default
+export ON_DEMAND_DEBUG_PODS="${ON_DEMAND_DEBUG_PODS:-true}"
+
 #Partner repo
 export TNF_PARTNER_REPO="${TNF_PARTNER_REPO:-quay.io/testnetworkfunction}"
 export TNF_DEPLOYMENT_TIMEOUT="${TNF_DEPLOYMENT_TIMEOUT:-240s}"
@@ -71,3 +74,5 @@ fi
 if [ $NUM -ge 0 ]; then
   export MULTUS_ANNOTATION="'[ ${MULTUS_ANNOTATION::-1} ]'"
 fi
+
+export 

--- a/test-partner/debugpartner.yaml
+++ b/test-partner/debugpartner.yaml
@@ -18,7 +18,7 @@ spec:
         test-network-function.com/app: debug
       name: debug
     spec:
-      {{NODE_SELECTOR}}
+      #{{NODE_SELECTOR}}
       containers:
         - command:
             - /bin/sh

--- a/test-partner/debugpartner.yaml
+++ b/test-partner/debugpartner.yaml
@@ -18,8 +18,7 @@ spec:
         test-network-function.com/app: debug
       name: debug
     spec:
-      nodeSelector:
-        test-network-function.com/node: target
+      {{NODE_SELECTOR}}
       containers:
         - command:
             - /bin/sh


### PR DESCRIPTION
New environment variable now controls whether to always create debug pods :
ON_DEMAND_DEBUG_PODS=false make install 