### PR TITLE
Add comments to missing scripts

### DIFF
--- a/scripts/deploy-all-linux-local-minikube.sh
+++ b/scripts/deploy-all-linux-local-minikube.sh
@@ -5,10 +5,10 @@ SCRIPT_DIR=$(dirname "$0")
 source $SCRIPT_DIR/init-env.sh
 
 $SCRIPT_DIR/create-local-registry.sh
-$SCRIPT_DIR/deploy-minikube.sh
+$SCRIPT_DIR/deploy-minikube.sh # not implemented
 $SCRIPT_DIR/deploy-test-pods.sh
 $SCRIPT_DIR/deploy-hpa.sh
-$SCRIPT_DIR/deploy-partner-pods.sh
+$SCRIPT_DIR/deploy-partner-pods.sh # not implemented
 $SCRIPT_DIR/create-secret.sh
 $SCRIPT_DIR/install-operator-sdk.sh
 $SCRIPT_DIR/install-olm.sh


### PR DESCRIPTION
The two scripts `deploy-minikube.sh` and `deploy-partner-pods.sh` do not exist.  I added some comments on their references.