### PR TITLE
Add terminationMessagePolicy to the deployed test pods

### DIFF
--- a/test-target/local-pod-under-test.yaml
+++ b/test-target/local-pod-under-test.yaml
@@ -59,6 +59,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
           command: ["./bin/app"]
+          terminationMessagePolicy: FallbackToLogsOnError
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/83

Docs:
https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/

By default, `terminationMessagePolicy` is set to `File`.