### PR TITLE
Fix sleep; add 'cat' to generated YAMLs

### DIFF
--- a/scripts/deploy-community-operator.sh
+++ b/scripts/deploy-community-operator.sh
@@ -26,12 +26,14 @@ fi
 mkdir -p ./temp
 cat ./test-target/community-operator-group.yaml | TNF_EXAMPLE_CNF_NAMESPACE=$TNF_EXAMPLE_CNF_NAMESPACE $SCRIPT_DIR/mo > ./temp/rendered-local-community-operator-group.yaml
 oc apply -f ./temp/rendered-local-community-operator-group.yaml
+cat ./temp/rendered-local-community-operator-group.yaml
 rm ./temp/rendered-local-community-operator-group.yaml
 
 # Create the Subscription
 mkdir -p ./temp
 cat ./test-target/community-operator-subscription.yaml | OPERATOR_NAME=$COMMUNITY_OPERATOR_BASE CATALOG_SOURCE=$CATALOG_SOURCE CATALOG_NAMESPACE=$CATALOG_NAMESPACE TNF_EXAMPLE_CNF_NAMESPACE=$TNF_EXAMPLE_CNF_NAMESPACE $SCRIPT_DIR/mo > ./temp/rendered-local-community-operator-subscription.yaml
 oc apply -f ./temp/rendered-local-community-operator-subscription.yaml
+cat ./temp/rendered-local-community-operator-subscription.yaml
 rm ./temp/rendered-local-community-operator-subscription.yaml
 
 

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -17,4 +17,4 @@ operator-sdk olm uninstall
 operator-sdk olm install --version=v0.20.0
 # Wait for all OLM pods to be ready
 kubectl wait --for=condition=ready pod --all=true -nolm --timeout=$TNF_DEPLOYMENT_TIMEOUT
-sleep 5s
+sleep 5


### PR DESCRIPTION
- Removed the `s` from the `sleep 5` command.
- Add some `cat` calls 🐱  to print out the generated YAMLs.