### PR TITLE
Preventing kubernetes version to be incremented automatically

### DIFF
--- a/config/k8s-cluster/config.yaml
+++ b/config/k8s-cluster/config.yaml
@@ -9,6 +9,10 @@ networking:
   apiServerPort: 6443
 nodes:
   - role: control-plane
+    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
   - role: worker
+    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
   - role: worker
+    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
   - role: worker
+    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c


### PR DESCRIPTION
k8s version set at 1.21.10 for the time being as this is compatible with our current scripts