### PR TITLE
Add vagrant-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ vagrant-suspend:
 vagrant-resume:
 	cd config/vagrant;vagrant resume
 
+# update the vagrant vm
+vagrant-update:
+	cd config/vagrant;vagrant box update
+
 # create a new docker configuration
 new-docker-config:
 	./scripts/configure-docker.sh


### PR DESCRIPTION
When running the `make vagrant-build` it prompted me that our underlying box was out of date:

```
$ make vagrant-build
mkdir -p config/vagrant/kubeconfig
vagrant plugin install vagrant-reload
Installing the 'vagrant-reload' plugin. This can take a few minutes...
Installed the plugin 'vagrant-reload (0.0.1)'!
cd config/vagrant;vagrant up;cd ../..
Bringing machine 'k8shost' up with 'virtualbox' provider...
==> k8shost: Checking if box 'generic/fedora34' version '3.6.8' is up to date...
==> k8shost: A newer version of the box 'generic/fedora34' for provider 'virtualbox' is
==> k8shost: available! You currently have version '3.6.8'. The latest is version
==> k8shost: '3.6.12'. Run `vagrant box update` to update.
```

There's no way to automatically perform the box update (by Vagrant's design) but there's an easy way to upgrade the box with `vagrant box update`.