### PR TITLE
Use pluto in github actions

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -34,6 +34,6 @@ jobs:
     steps:
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@master
-      - name: Use pluto
+      - name: Check examples folder
         run: |
           pluto detect-files

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -28,3 +28,12 @@ jobs:
                 level: warning
               braces:
                 level: warning
+  deprecated-k8s-check:
+    name: Pluto Deprecated Version Check
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download Pluto
+        uses: FairwindsOps/pluto/github-action@master
+      - name: Use pluto
+        run: |
+          pluto detect-files


### PR DESCRIPTION
Same as: https://github.com/test-network-function/cnf-certification-test/pull/144 

Checks PRs against `pluto` for any deprecated k8s manifests.

![image](https://user-images.githubusercontent.com/4563082/164739539-97527cbe-2a54-436b-a420-ea12a4967f2e.png)
