### PR TITLE
Automatically use latest stable ocp release

### DIFF
--- a/config/vagrant/scripts/bootstrap-cluster.sh
+++ b/config/vagrant/scripts/bootstrap-cluster.sh
@@ -4,8 +4,11 @@
 sudo curl -Lo /usr/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-linux-amd64
 sudo chmod +x /usr/bin/kind
 
-# download openshift client
-OPENSHIFT_VERSION="4.9.9"
+# download the latest openshift client at a certain release level
+RELEASE_LEVEL="4.10"
+VERSIONS=($(sudo curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort))
+OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
+
 OC_BIN_TAR="openshift-client-linux.tar.gz"
 OC_DL_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp"/${OPENSHIFT_VERSION}/${OC_BIN_TAR}
 

--- a/config/vagrant/scripts/bootstrap-docker.sh
+++ b/config/vagrant/scripts/bootstrap-docker.sh
@@ -21,7 +21,7 @@ sudo dnf remove docker \
 
 # Install docker
 sudo dnf -y install dnf-plugins-core
-sudo dnf -y install docker-ce docker-ce-cli containerd.io
+sudo dnf -y install docker-ce docker-ce-cli containerd.io jq
 
 # Configure IPv6 in docker ( https://docs.docker.com/config/daemon/ipv6/ )
 sudo mkdir /etc/docker


### PR DESCRIPTION
Instead of hardcoding a specific version eg. "4.9.9" like we do currently, I modified the bootstrap scripts to point at a minor release level and use the latest stable version available whenever building.

At the time of making this PR, 4.10's latest patch release is 4.10.9.

```
[vagrant@k8shost ~]$ oc version
Client Version: 4.10.9
Kubernetes Version: v1.21.10
```

I will be making the same change in other other repos as well so we don't have to worry about the patch versions.