### PR TITLE
Fix init-env.sh error in non ocp clusters.

### DIFF
--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -78,8 +78,8 @@ then
   create_multus_annotation "ipv4"
   # IPv6
   create_multus_annotation "ipv6"
-fi
 
-if [ "$NUM" -ge 0 ]; then
-  export MULTUS_ANNOTATION="'[ ${MULTUS_ANNOTATION::-1} ]'"
+  if [ "$NUM" -ge 0 ]; then
+    export MULTUS_ANNOTATION="'[ ${MULTUS_ANNOTATION::-1} ]'"
+  fi
 fi


### PR DESCRIPTION
The NUM variable does not exist for non ocp clusters so it was showing
this error:
[2022-05-11T07:34:16.603Z] ++ '[' '' -ge 0 ']'
[2022-05-11T07:34:16.603Z] ./scripts/init-env.sh: line 83: [: : integer
expression expected