### PR TITLE
Upgrade to v3 checkout action

### DIFF
--- a/.github/workflows/cnf-test-partner-image.yaml
+++ b/.github/workflows/cnf-test-partner-image.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: 'Build the `cnf-test-partner` image'
         run: docker build  -t $IMAGE_NAME:$IMAGE_TAG . --no-cache -f $IMAGE_CONTAINER_FILE_PATH
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout the main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
 

--- a/.github/workflows/debug-partner-image.yaml
+++ b/.github/workflows/debug-partner-image.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: 'Build the `debug-partner` image'
         run: docker build --no-cache -f Dockerfile.debug-partner -t $IMAGE_NAME:$IMAGE_TAG .
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout the main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
 

--- a/.github/workflows/local-test-infra.yaml
+++ b/.github/workflows/local-test-infra.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
@@ -26,7 +26,7 @@ jobs:
       DEFAULT_TIMEOUT: 90s
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Start the k8s cluster
         uses: ./.github/actions/start-k8s-cluster

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -11,7 +11,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
         with:
@@ -32,7 +32,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/204 

https://github.com/actions/checkout/releases/tag/v3.0.2

`checkout` v3 is the latest available.