### PR TITLE
Add check for existing HPA

### DIFF
--- a/scripts/deploy-hpa.sh
+++ b/scripts/deploy-hpa.sh
@@ -4,5 +4,9 @@
 SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
-# create hpa on the test deployment
-oc autoscale deployment test -n "$TNF_EXAMPLE_CNF_NAMESPACE" --cpu-percent=50 --min=2 --max=3
+# Check for existing HPA first
+HPA_EXISTS=$(oc get hpa test -n "$TNF_EXAMPLE_CNF_NAMESPACE")
+if [ $? -ne 0 ]; then
+    # create hpa on the test deployment
+    oc autoscale deployment test -n "$TNF_EXAMPLE_CNF_NAMESPACE" --cpu-percent=50 --min=2 --max=3
+fi

--- a/scripts/deploy-statefulset-test-pods.sh
+++ b/scripts/deploy-statefulset-test-pods.sh
@@ -13,4 +13,8 @@ sleep 3
 oc wait -l statefulset.kubernetes.io/pod-name=test-0 -n "$TNF_EXAMPLE_CNF_NAMESPACE" --for=condition=ready pod --timeout="$TNF_DEPLOYMENT_TIMEOUT"
 oc wait -l statefulset.kubernetes.io/pod-name=test-1 -n "$TNF_EXAMPLE_CNF_NAMESPACE" --for=condition=ready pod --timeout="$TNF_DEPLOYMENT_TIMEOUT"
 
-oc autoscale statefulset test -n "$TNF_EXAMPLE_CNF_NAMESPACE" --cpu-percent=50 --min=2 --max=3
+# Check for existing HPA first
+HPA_EXISTS=$(oc get hpa test -n "$TNF_EXAMPLE_CNF_NAMESPACE")
+if [ $? -ne 0 ]; then
+    oc autoscale statefulset test -n "$TNF_EXAMPLE_CNF_NAMESPACE" --cpu-percent=50 --min=2 --max=3
+fi


### PR DESCRIPTION
Prior to this, running `make install` if you have already ran it prior would end in:

```
+ oc wait -l statefulset.kubernetes.io/pod-name=test-0 -n tnf --for=condition=ready pod --timeout=240s
pod/test-0 condition met
+ oc wait -l statefulset.kubernetes.io/pod-name=test-1 -n tnf --for=condition=ready pod --timeout=240s
pod/test-1 condition met
+ oc autoscale statefulset test -n tnf --cpu-percent=50 --min=2 --max=3
Error from server (AlreadyExists): horizontalpodautoscalers.autoscaling "test" already exists
make: *** [install] Error 1
```

The goal is to check if the `test` HPA already exists and skip it.