### PR TITLE
Update Kind to v0.14.0

### DIFF
--- a/.github/actions/start-k8s-cluster/action.yaml
+++ b/.github/actions/start-k8s-cluster/action.yaml
@@ -4,7 +4,7 @@ inputs:
   working_directory:
     default: .
   kind_version:
-    default: v0.12.0
+    default: v0.14.0
   oc_kcm_timeout:
     default: 5m
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ sudo systemctl restart docker
 
 Download and install Kubernetes In Docker (Kind):
 ```shell-script
-curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-linux-amd64
+curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.14.0/kind-linux-amd64
 ```
 
 Configure a cluster with 4 worker nodes and one master node ( dual stack ): 

--- a/config/k8s-cluster/calico.yaml
+++ b/config/k8s-cluster/calico.yaml
@@ -2827,7 +2827,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.22.2
+          image: docker.io/calico/cni:v3.23.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
             - configMapRef:
@@ -2854,7 +2854,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.22.2
+          image: docker.io/calico/cni:v3.23.1
           command: ["/opt/cni/bin/install"]
           envFrom:
             - configMapRef:
@@ -2895,7 +2895,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.22.2
+          image: docker.io/calico/pod2daemon-flexvol:v3.23.1
           volumeMounts:
             - name: flexvol-driver-host
               mountPath: /host/driver
@@ -2906,7 +2906,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.22.2
+          image: docker.io/calico/node:v3.23.1
           envFrom:
             - configMapRef:
                 # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -3125,7 +3125,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.22.2
+          image: docker.io/calico/kube-controllers:v3.23.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/config/vagrant/scripts/bootstrap-cluster.sh
+++ b/config/vagrant/scripts/bootstrap-cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Download and install Kubernetes In Docker (Kind):
-sudo curl -Lo /usr/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-linux-amd64
+sudo curl -Lo /usr/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.14.0/kind-linux-amd64
 sudo chmod +x /usr/bin/kind
 
 # download the latest openshift client at a certain release level

--- a/scripts/clean-all.sh
+++ b/scripts/clean-all.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR"/init-env.sh
 ./"$SCRIPT_DIR"/delete-debug-ds.sh
 
 # Delete namespace
-oc delete namespace "${TNF_EXAMPLE_CNF_NAMESPACE}"
+oc delete namespace "${TNF_EXAMPLE_CNF_NAMESPACE}" --ignore-not-found=true
 
 # Delete test CRDs
 "$SCRIPT_DIR"/delete-test-crds.sh

--- a/scripts/create-secret.sh
+++ b/scripts/create-secret.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR"/init-env.sh
 if [[ -n "$(ls "$SCRIPT_DIR"/certs/registry.pem  2>/dev/null)" ]]; then
   echo "pem file found, create secret from pem file"
   cp "$SCRIPT_DIR"/certs/registry.pem "$SCRIPT_DIR"/certs/cert.pem
-  oc delete secret "$SECRET_NAME" -n "$TNF_EXAMPLE_CNF_NAMESPACE"
+  oc delete secret "$SECRET_NAME" -n "$TNF_EXAMPLE_CNF_NAMESPACE" --ignore-not-found=true
   oc create secret generic "$SECRET_NAME" --from-file="$SCRIPT_DIR"/certs/cert.pem  -n "$TNF_EXAMPLE_CNF_NAMESPACE"
 else
   echo "No pem file present, skipping secret creation"

--- a/scripts/delete-community-operator.sh
+++ b/scripts/delete-community-operator.sh
@@ -5,10 +5,10 @@ SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
 # delete CSV
-oc delete csv "$COMMUNITY_OPERATOR_NAME" -n "$TNF_EXAMPLE_CNF_NAMESPACE"
+oc delete csv "$COMMUNITY_OPERATOR_NAME" -n "$TNF_EXAMPLE_CNF_NAMESPACE" --ignore-not-found=true
 
 # delete operator group
-oc delete operatorgroups test-group -n "$TNF_EXAMPLE_CNF_NAMESPACE"
+oc delete operatorgroups test-group -n "$TNF_EXAMPLE_CNF_NAMESPACE" --ignore-not-found=true
 
 # delete subscription
-oc delete subscriptions test-subscription -n "$TNF_EXAMPLE_CNF_NAMESPACE"
+oc delete subscriptions test-subscription -n "$TNF_EXAMPLE_CNF_NAMESPACE" --ignore-not-found=true

--- a/scripts/delete-debug-ds.sh
+++ b/scripts/delete-debug-ds.sh
@@ -5,5 +5,5 @@ SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
 # Delete debug daemonset
-oc delete  daemonsets.apps/debug -n "${DEFAULT_NAMESPACE}"
+oc delete  daemonsets.apps/debug -n "${DEFAULT_NAMESPACE}" --ignore-not-found=true
 until [[ -z "$(oc get ds debug -n "${DEFAULT_NAMESPACE}" 2>/dev/null)" ]]; do sleep 5; done

--- a/scripts/delete-hpa.sh
+++ b/scripts/delete-hpa.sh
@@ -5,4 +5,4 @@ SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
 # Delete the hpa 
-oc delete hpa test -n "${TNF_EXAMPLE_CNF_NAMESPACE}"
+oc delete hpa test -n "${TNF_EXAMPLE_CNF_NAMESPACE}" --ignore-not-found=true

--- a/scripts/delete-litmus-operator.sh
+++ b/scripts/delete-litmus-operator.sh
@@ -4,4 +4,4 @@
 SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
-oc delete -f ./scripts/operator-ce.yaml
+oc delete -f ./scripts/operator-ce.yaml --ignore-not-found=true

--- a/scripts/delete-statefulset-pods.sh
+++ b/scripts/delete-statefulset-pods.sh
@@ -5,4 +5,4 @@ SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
 # Delete test deployment
-oc delete  statefulsets.apps/test -n "${TNF_EXAMPLE_CNF_NAMESPACE}"
+oc delete  statefulsets.apps/test -n "${TNF_EXAMPLE_CNF_NAMESPACE}" --ignore-not-found=true

--- a/scripts/delete-test-crds.sh
+++ b/scripts/delete-test-crds.sh
@@ -5,4 +5,4 @@ SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
 # Delete test deployment
-oc delete crd crdexamples.test-network-function.com
+oc delete crd crdexamples.test-network-function.com --ignore-not-found=true

--- a/scripts/delete-test-pods.sh
+++ b/scripts/delete-test-pods.sh
@@ -5,4 +5,4 @@ SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
 # Delete test deployment
-oc delete  deployment.apps/test -n "${TNF_EXAMPLE_CNF_NAMESPACE}"
+oc delete  deployment.apps/test -n "${TNF_EXAMPLE_CNF_NAMESPACE}" --ignore-not-found=true


### PR DESCRIPTION
Links:
https://github.com/kubernetes-sigs/kind/releases/tag/v0.14.0

Also:
- I added --ignore-not-found on the `oc delete` commands to get rid of those NotFound errors on `make clean`.
- Updated Calico to v3.23.1.

Note: It seems that we still have to keep the `kindest` image set to the 1.21.10 image for now as it doesn't seem to work yet to use to most current version.
