### PR TITLE
Zoperator fix

### DIFF
--- a/config/k8s-cluster/config.yaml
+++ b/config/k8s-cluster/config.yaml
@@ -9,10 +9,10 @@ networking:
   apiServerPort: 6443
 nodes:
   - role: control-plane
-    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
+    image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1
   - role: worker
-    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
+    image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1
   - role: worker
-    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
+    image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1
   - role: worker
-    image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
+    image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1

--- a/scripts/deploy-community-operator.sh
+++ b/scripts/deploy-community-operator.sh
@@ -17,11 +17,11 @@ if [ "$CATALOG_CHECK_RETRIES" -le 0  ]; then
 	exit 1
 fi
 
-if [[ -z "$(oc get packagemanifests | grep zoperator 2>/dev/null)" ]]; then
-  echo "zoperator package was not found in the catalog, skipping installation"
+if [[ -z "$(oc get packagemanifests | grep instana-agent 2>/dev/null)" ]]; then
+  echo "instana-agent package was not found in the catalog, skipping installation"
   exit 0
 fi
-echo "zoperator package found, starting installation"
+echo "instana-agent package found, starting installation"
 
 #check if operator-sdk is installed and install it if needed
 if [[ -z "$(which operator-sdk 2>/dev/null)" ]]; then
@@ -50,7 +50,7 @@ rm ./temp/rendered-local-community-operator-group.yaml
 
 # Create the Subscription
 mkdir -p ./temp
-cat ./test-target/community-operator-subscription.yaml | OPERATOR_NAME=$COMMUNITY_OPERATOR_BASE CATALOG_SOURCE=$CATALOG_SOURCE CATALOG_NAMESPACE=$CATALOG_NAMESPACE TNF_EXAMPLE_CNF_NAMESPACE=$TNF_EXAMPLE_CNF_NAMESPACE "$SCRIPT_DIR"/mo > ./temp/rendered-local-community-operator-subscription.yaml
+cat ./test-target/community-operator-subscription.yaml | OPERATOR_CHANNEL=stable OPERATOR_NAME=$COMMUNITY_OPERATOR_BASE CATALOG_SOURCE=$CATALOG_SOURCE CATALOG_NAMESPACE=$CATALOG_NAMESPACE TNF_EXAMPLE_CNF_NAMESPACE=$TNF_EXAMPLE_CNF_NAMESPACE "$SCRIPT_DIR"/mo > ./temp/rendered-local-community-operator-subscription.yaml
 oc apply -f ./temp/rendered-local-community-operator-subscription.yaml
 cat ./temp/rendered-local-community-operator-subscription.yaml
 rm ./temp/rendered-local-community-operator-subscription.yaml

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -14,9 +14,9 @@ OPERATOR_BUNDLE_IMAGE_FULL_NAME=$REGISTRY$DIRECTORY$OPERATOR_BUNDLE_IMAGE
 OPERATOR_IMAGE_FULL_NAME=$REGISTRY$DIRECTORY$OPERATOR_IMAGE
 OPERATOR_REGISTRY_POD_NAME_FULL=$(echo $OPERATOR_BUNDLE_IMAGE_FULL_NAME|sed 's/[\/|\.|:]/-/g')
 
-# Community operator name (03/29/2022 only zoperator is both community and redhat certified)
-COMMUNITY_OPERATOR_NAME=zoperator.v0.3.6
-COMMUNITY_OPERATOR_BASE=zoperator
+COMMUNITY_OPERATOR_NAME=instana-agent-operator.v2.0.5
+COMMUNITY_OPERATOR_BASE=instana-agent-operator
+
 
 # Truncate registry pod name if more than 63 characters
 if [[ ${#OPERATOR_REGISTRY_POD_NAME_FULL} -gt 63 ]];then

--- a/test-partner/debugpartner.yaml
+++ b/test-partner/debugpartner.yaml
@@ -60,6 +60,8 @@ spec:
           tolerationSeconds: 300
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
       volumes:
         - hostPath:
             path: /

--- a/test-target/community-operator-group.yaml
+++ b/test-target/community-operator-group.yaml
@@ -4,5 +4,5 @@ metadata:
   name: test-group
   namespace: {{ TNF_EXAMPLE_CNF_NAMESPACE }}
 spec:
-  targetNamespaces:
-    - {{ TNF_EXAMPLE_CNF_NAMESPACE }}
+  # targetNamespaces:
+  #   - {{ TNF_EXAMPLE_CNF_NAMESPACE }}

--- a/test-target/community-operator-subscription.yaml
+++ b/test-target/community-operator-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-subscription
   namespace: {{ TNF_EXAMPLE_CNF_NAMESPACE }} 
 spec:
-  channel: alpha
+  channel: {{ OPERATOR_CHANNEL }}
   name: {{ OPERATOR_NAME }}
   source: {{ CATALOG_SOURCE }}
   sourceNamespace: {{ CATALOG_NAMESPACE }}


### PR DESCRIPTION
#126 was my first attempt at this, but I was missing: 

```
- effect: NoSchedule
          key: node-role.kubernetes.io/control-plane
```

In Kubernetes 1.24 (the version of kindest/node we are using in this PR) the new toleration is "control-plane" instead of "master".