### PR TITLE
Remove installing litmus from 'make install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ install:
 	./scripts/deploy-debug-ds.sh
 	./scripts/install-olm.sh
 	./scripts/deploy-community-operator.sh
-	./scripts/install-litmus-operator.sh
 
 # creates a k8s cluster instance
 rebuild-cluster:


### PR DESCRIPTION
As part of `make install`, we should follow the same idea as [PR#316](https://github.com/test-network-function/cnf-certification-test/pull/316) where we remove the litmus operator install from the main flow.

Note, `make install-litmus` and `make delete-litmus` are still available but I wanted to remove it from the `make install` workflow.