### PR TITLE
Upgrade kindest/node to v1.24.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ oc get pods -n $TNF_EXAMPLE_CNF_NAMESPACE -o wide
 You should see something like this (note that the 2 test pods are running on different nodes due to a anti-affinity rule):
 ```shell-script
 $ oc get pods -ntnf -owide
-NAME                         READY   STATUS    RESTARTS   AGE   IP               NODE           NOMINATED NODE   READINESS GATES
-test-0                       1/1     Running   0          15m   10.244.162.133   kind-worker    <none>           <none>
-test-1                       1/1     Running   0          15m   10.244.110.166   kind-worker2   <none>           <none>
-test-6cbd5b97b7-d5756        1/1     Running   0          15m   10.244.110.165   kind-worker2   <none>           <none>
-test-6cbd5b97b7-xgpt6        1/1     Running   0          15m   10.244.195.209   kind-worker3   <none>           <none>
-zoperator-54cdd7f77c-ddhwm   1/1     Running   0          12m   10.244.195.217   kind-worker3   <none>           <none>
+NAME                                                    READY   STATUS    RESTARTS   AGE
+hazelcast-platform-controller-manager-6bbc968f9-fmmbs   1/1     Running   0          3m19s
+test-0                                                  1/1     Running   0          84m
+test-1                                                  1/1     Running   0          83m
+test-66f77bd94-2w4l8                                    1/1     Running   0          85m
+test-66f77bd94-6kd6j                                    1/1     Running   0          85m
 
 ```
 ### Delete local-test-infra

--- a/config/k8s-cluster/config.yaml
+++ b/config/k8s-cluster/config.yaml
@@ -9,10 +9,10 @@ networking:
   apiServerPort: 6443
 nodes:
   - role: control-plane
-    image: kindest/node:v1.21.12@sha256:05eefdedfcb6113402ac631782adfa3d9f8b75c38eac783e3da4f44f6404dae0
+    image: kindest/node:v1.24.4@sha256:ba6a8a1bc35139cc0947a9269a6db577cf7a6ba37cab8088fd04142546dc0c21
   - role: worker
-    image: kindest/node:v1.21.12@sha256:05eefdedfcb6113402ac631782adfa3d9f8b75c38eac783e3da4f44f6404dae0
+    image: kindest/node:v1.24.4@sha256:ba6a8a1bc35139cc0947a9269a6db577cf7a6ba37cab8088fd04142546dc0c21
   - role: worker
-    image: kindest/node:v1.21.12@sha256:05eefdedfcb6113402ac631782adfa3d9f8b75c38eac783e3da4f44f6404dae0
+    image: kindest/node:v1.24.4@sha256:ba6a8a1bc35139cc0947a9269a6db577cf7a6ba37cab8088fd04142546dc0c21
   - role: worker
-    image: kindest/node:v1.21.12@sha256:05eefdedfcb6113402ac631782adfa3d9f8b75c38eac783e3da4f44f6404dae0
+    image: kindest/node:v1.24.4@sha256:ba6a8a1bc35139cc0947a9269a6db577cf7a6ba37cab8088fd04142546dc0c21

--- a/scripts/deploy-community-operator.sh
+++ b/scripts/deploy-community-operator.sh
@@ -17,11 +17,11 @@ if [ "$CATALOG_CHECK_RETRIES" -le 0  ]; then
 	exit 1
 fi
 
-if [[ -z "$(oc get packagemanifests | grep zoperator 2>/dev/null)" ]]; then
-  echo "zoperator package was not found in the catalog, skipping installation"
+if [[ -z "$(oc get packagemanifests | grep hazelcast 2>/dev/null)" ]]; then
+  echo "hazelcast package was not found in the catalog, skipping installation"
   exit 0
 fi
-echo "zoperator package found, starting installation"
+echo "hazelcast package found, starting installation"
 
 #check if operator-sdk is installed and install it if needed
 if [[ -z "$(which operator-sdk 2>/dev/null)" ]]; then

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -14,9 +14,9 @@ OPERATOR_BUNDLE_IMAGE_FULL_NAME=$REGISTRY$DIRECTORY$OPERATOR_BUNDLE_IMAGE
 OPERATOR_IMAGE_FULL_NAME=$REGISTRY$DIRECTORY$OPERATOR_IMAGE
 OPERATOR_REGISTRY_POD_NAME_FULL=$(echo $OPERATOR_BUNDLE_IMAGE_FULL_NAME|sed 's/[\/|\.|:]/-/g')
 
-# Community operator name (03/29/2022 only zoperator is both community and redhat certified)
-COMMUNITY_OPERATOR_NAME=zoperator.v0.3.6
-COMMUNITY_OPERATOR_BASE=zoperator
+# Community operator name
+COMMUNITY_OPERATOR_NAME=hazelcast-platform-operator.v5.4.0
+COMMUNITY_OPERATOR_BASE=hazelcast-platform-operator
 
 # Truncate registry pod name if more than 63 characters
 if [[ ${#OPERATOR_REGISTRY_POD_NAME_FULL} -gt 63 ]];then


### PR DESCRIPTION
- Update kindest/node to v1.24.4
- Update installed operator to `hazelcast-platform-operator`

Links:
- https://operatorhub.io/operator/hazelcast-platform-operator
- https://catalog.redhat.com/software/operators/detail/62fe161d826cc98d217ef943
- https://hub.docker.com/layers/kindest/node/v1.24.4/images/sha256-ba6a8a1bc35139cc0947a9269a6db577cf7a6ba37cab8088fd04142546dc0c21?context=explore