### PR TITLE
Remove prometheus folder post-install

### DIFF
--- a/scripts/install-prometheus-operator.sh
+++ b/scripts/install-prometheus-operator.sh
@@ -19,3 +19,5 @@ oc wait \
 	--namespace=monitoring \
 	--timeout="$TNF_DEPLOYMENT_TIMEOUT"
 oc get pods -A | grep prometheus
+
+rm -rf kube-prometheus


### PR DESCRIPTION
The `vagrant-build` was failing with:

```
    k8shost: + git clone https://github.com/prometheus-operator/kube-prometheus.git --depth 1 -b v0.11.0
    k8shost: fatal: destination path 'kube-prometheus' already exists and is not an empty directory.
    k8shost: make: *** [Makefile:23: install] Error 128
```