### PR TITLE
Partner daemonset: Added operator Exists to tolerations.

### DIFF
--- a/test-partner/debugpartner.yaml
+++ b/test-partner/debugpartner.yaml
@@ -59,8 +59,10 @@ spec:
           operator: Exists
           tolerationSeconds: 300
         - effect: NoSchedule
+          operator: Exists
           key: node-role.kubernetes.io/master
         - effect: NoSchedule
+          operator: Exists
           key: node-role.kubernetes.io/control-plane
       volumes:
         - hostPath:


### PR DESCRIPTION
Kind cluster with nodes v1.24 adds the new taint
node-role.kubernetes.io/control-plane to the master+worker node.

For some unknown reason, when the partner daemonset is deployed, the "/control-plane" toleration is not applied (it doesn't appear in the yaml output), so no pods cannot be deployed on the master-worker node.

Adding the "Exists" operator to the pod spec for both master and control-plane tolerations seems to make it work.

Signed-off-by: Gonzalo Reyero Ferreras <greyerof@redhat.com>