### PR TITLE
Update Go to v1.19.2

### DIFF
--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -4,7 +4,7 @@ RUN dnf install -y wget make hostname iproute iputils openssh openssh-clients po
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.19.1.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.19.2.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/xtuG5faxtaU

Security: Includes security fixes for archive/tar (CVE-2022-2879), net/http (CVE-2022-2880), and regexp (CVE-2022-41715).

Related to: https://github.com/test-network-function/cnf-certification-test/pull/571