### PR TITLE
Adding Poststart section and reverting multus update

### DIFF
--- a/test-target/local-pod-under-test.yaml
+++ b/test-target/local-pod-under-test.yaml
@@ -37,6 +37,9 @@ spec:
               memory: 512Mi
               cpu: 0.25
           lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
             preStop:
               exec:
                 command: ["/bin/sh", "-c", "killall -0 tail"]


### PR DESCRIPTION
Adding postStart section and reverting latest multus update while investigating issue with image name

below error with multus pods:

Warning  Failed     52m (x4 over 53m)      kubelet            Failed to pull image "ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.2-v3.9.2-thick-amd64-amd64": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.2-v3.9.2-thick-amd64-amd64": failed to resolve reference "ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.2-v3.9.2-thick-amd64-amd64": ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.2-v3.9.2-thick-amd64-amd64: not found
  Warning  Failed     52m (x4 over 53m)      kubelet            Error: ErrImagePull
  Warning  Failed     51m (x6 over 53m)      kubelet            Error: ImagePullBackOff
  Normal   BackOff    3m31s (x216 over 53m)  kubelet            Back-off pulling image "ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.2-v3.9.2-thick-amd64-amd64"