### PR TITLE
Make TNF image pass preflight

### DIFF
--- a/.github/workflows/cnf-test-partner-image.yaml
+++ b/.github/workflows/cnf-test-partner-image.yaml
@@ -13,6 +13,7 @@ env:
   IMAGE_NAME: testnetworkfunction/cnf-test-partner
   IMAGE_TAG: latest
   IMAGE_CONTAINER_FILE_PATH: ./test-partner/Dockerfile
+  SPECIFIC_IMAGE_TAG: tag1
 
 jobs:
   test-cnf-test-partner-image:
@@ -23,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: 'Build the `cnf-test-partner` image'
-        run: docker build  -t $IMAGE_NAME:$IMAGE_TAG . --no-cache -f $IMAGE_CONTAINER_FILE_PATH
+        run: docker build  -t $IMAGE_NAME:$IMAGE_TAG -t $IMAGE_NAME:$SPECIFIC_IMAGE_TAG . --no-cache -f $IMAGE_CONTAINER_FILE_PATH
         working-directory: .
 
       - name: 'Test: Check if ping is installed'
@@ -56,9 +57,9 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: 'Build and push the new `cnf-test-partner` image'
+      - name: 'Build and push the new `cnf-test-partner` image(s)'
         uses: docker/build-push-action@v3
         with:
           push: true
           file: ${{ env.IMAGE_CONTAINER_FILE_PATH }}
-          tags: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}'
+          tags: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.SPECIFIC_IMAGE_TAG }}'

--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -1,5 +1,11 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
+ARG USERNAME=tnf-user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
 RUN dnf install -y wget make hostname iproute iputils openssh openssh-clients podman psmisc ethtool
 
 # Install Go binary
@@ -17,6 +23,9 @@ RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \
 
 # Add go and oc binary directory to $PATH
 ENV PATH="/bin/":"/usr/local/go/bin":${GOPATH}"/bin/":"${PATH}"
+
+# Add arbitrary /licenses folder to pass preflight
+RUN mkdir /licenses
 
 RUN echo ${PATH}
 


### PR DESCRIPTION
This is part 1.  I just want to get the `tag1` image building and pushing the quay then I can switch the actual tnf image over to use `tag1` or whatever we want to call it.