### PR TITLE
Skip prometheus install/delete if OCP

### DIFF
--- a/scripts/delete-prometheus-operator.sh
+++ b/scripts/delete-prometheus-operator.sh
@@ -4,4 +4,9 @@
 SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
+if ! $TNF_NON_OCP_CLUSTER;then
+	echo "OCP cluster detected, skipping prometheus operator deletion"
+	exit 0
+fi
+
 oc delete  --filename ./kube-prometheus -n "monitoring" --ignore-not-found=true

--- a/scripts/install-prometheus-operator.sh
+++ b/scripts/install-prometheus-operator.sh
@@ -4,6 +4,11 @@ set -o errexit
 SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
+if ! $TNF_NON_OCP_CLUSTER;then
+	echo "OCP cluster detected, skipping prometheus operator installation"
+	exit 0
+fi
+
 # Clear any existing kube-prometheus folders
 rm -rf kube-prometheus
 


### PR DESCRIPTION
Skip installation/deletion of prometheus operator to prevent problems in real OCP clusters.