### PR TITLE
Update Go to v1.19.5

### DIFF
--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf install -y wget make hostname iproute iputils openssh openssh-clients po
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.19.4.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.19.5.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/wrmRT7JlevE

Related to: https://github.com/test-network-function/cnf-certification-test/pull/779