### PR TITLE
Always use a name with version for hazelcast

### DIFF
--- a/scripts/deploy-community-operator.sh
+++ b/scripts/deploy-community-operator.sh
@@ -50,7 +50,7 @@ rm ./temp/rendered-local-community-operator-group.yaml
 
 # Create the Subscription
 mkdir -p ./temp
-cat ./test-target/community-operator-subscription.yaml | OPERATOR_NAME=$COMMUNITY_OPERATOR_BASE CATALOG_SOURCE=$CATALOG_SOURCE CATALOG_NAMESPACE=$CATALOG_NAMESPACE TNF_EXAMPLE_CNF_NAMESPACE=$TNF_EXAMPLE_CNF_NAMESPACE "$SCRIPT_DIR"/mo > ./temp/rendered-local-community-operator-subscription.yaml
+cat ./test-target/community-operator-subscription.yaml | OPERATOR_NAME=$COMMUNITY_OPERATOR_NAME CATALOG_SOURCE=$CATALOG_SOURCE CATALOG_NAMESPACE=$CATALOG_NAMESPACE TNF_EXAMPLE_CNF_NAMESPACE=$TNF_EXAMPLE_CNF_NAMESPACE "$SCRIPT_DIR"/mo > ./temp/rendered-local-community-operator-subscription.yaml
 oc apply --filename ./temp/rendered-local-community-operator-subscription.yaml
 cat ./temp/rendered-local-community-operator-subscription.yaml
 rm ./temp/rendered-local-community-operator-subscription.yaml

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -16,7 +16,6 @@ OPERATOR_REGISTRY_POD_NAME_FULL=$(echo $OPERATOR_BUNDLE_IMAGE_FULL_NAME|sed 's/[
 
 # Community operator name
 COMMUNITY_OPERATOR_NAME=hazelcast-platform-operator.v5.5.0
-COMMUNITY_OPERATOR_BASE=hazelcast-platform-operator
 
 # Truncate registry pod name if more than 63 characters
 if [[ ${#OPERATOR_REGISTRY_POD_NAME_FULL} -gt 63 ]];then


### PR DESCRIPTION
The installation is done with `COMMUNITY_OPERATOR_BASE`, which takes the latest version, but the checking is done with `COMMUNITY_OPERATOR_NAME` with a version. So it will always fail on `hazelcast` update. The fix is to use `COMMUNITY_OPERATOR_NAME` for everything.