### PR TITLE
Workaround to remove non compliant newly introduce services

### DIFF
--- a/scripts/deploy-operator.sh
+++ b/scripts/deploy-operator.sh
@@ -40,3 +40,6 @@ else
   echo "ERROR: CSV not deployed. Operator deployment failed -- interrupting tests"
   exit 1
 fi
+
+# Workaround to remove the non compliant hazelcast services
+oc delete service  -ntnf hazelcast-platform-controller-manager-service  hazelcast-platform-webhook-service

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -15,7 +15,7 @@ OPERATOR_IMAGE_FULL_NAME=$REGISTRY$DIRECTORY$OPERATOR_IMAGE
 OPERATOR_REGISTRY_POD_NAME_FULL=$(echo $OPERATOR_BUNDLE_IMAGE_FULL_NAME|sed 's/[\/|\.|:]/-/g')
 
 # Community operator name
-COMMUNITY_OPERATOR_NAME=hazelcast-platform-operator.v5.5.0
+COMMUNITY_OPERATOR_NAME=hazelcast-platform-operator.v5.6.0
 COMMUNITY_OPERATOR_BASE=hazelcast-platform-operator
 
 # Truncate registry pod name if more than 63 characters


### PR DESCRIPTION
Allows using hazelcast 5.6.0 and pass dual stack / ipv6 check