### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf install -y wget make hostname iproute iputils openssh openssh-clients po
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.19.6.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.20.1.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \

--- a/testapp/go.mod
+++ b/testapp/go.mod
@@ -1,3 +1,3 @@
 module main
 
-go 1.19
+go 1.20


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873