### PR TITLE
Add Go to k8shost; comment out prom-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ install:
 	./scripts/deploy-community-operator.sh
 	./scripts/manage-service.sh deploy
 	./scripts/deploy-network-policies.sh
-	./scripts/install-prometheus-operator.sh
-	 ./scripts/deploy-operator-crd-scaling.sh
+	# ./scripts/install-prometheus-operator.sh
+	# ./scripts/deploy-operator-crd-scaling.sh
 
 # creates a k8s cluster instance
 rebuild-cluster:

--- a/config/vagrant/Vagrantfile
+++ b/config/vagrant/Vagrantfile
@@ -15,6 +15,11 @@ Vagrant.configure('2') do |config|
       vb.customize ['modifyvm', :id, '--graphicscontroller', 'vmsvga']
     end
 
+    # Install Go
+    k8shost.vm.provision 'shell',
+                         path: 'scripts/bootstrap-golang.sh',
+                         privileged: false
+
     # Configures docker.
     k8shost.vm.provision 'shell',
                          path: 'scripts/bootstrap-docker.sh',

--- a/config/vagrant/scripts/bootstrap-docker.sh
+++ b/config/vagrant/scripts/bootstrap-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dnf update -y
+sudo dnf update -y
 echo "192.168.56.10  k8shost" >> /etc/hosts
 
 # Adding docker repository

--- a/config/vagrant/scripts/bootstrap-golang.sh
+++ b/config/vagrant/scripts/bootstrap-golang.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo dnf update -y
+sudo dnf install golang -y


### PR DESCRIPTION
Disabling the CRD operator again until we can figure out what's going on with the installation of the resources.

#210 requires Go to be installed in the `k8shost` during vagrant runs for `make manifests` for example.

I also commented out the prometheus operator as we are not using it currently for any tests.