### PR TITLE
Improve vagrant and Makefile for self-hosted runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,16 @@ install:
 	# ./scripts/install-prometheus-operator.sh
 	 ./scripts/deploy-operator-crd-scaling.sh
 
+# Bootstrap Fedora Machine Locally
+bootstrap-docker-fedora-local:
+	cd config/vagrant/scripts; ./bootstrap-docker.sh
+
+bootstrap-golang-fedora-local:
+	cd config/vagrant/scripts; ./bootstrap-golang.sh
+
+bootstrap-cluster-fedora-local:
+	cd config/vagrant/scripts; ./bootstrap-cluster.sh
+
 # creates a k8s cluster instance
 rebuild-cluster:
 	./scripts/deploy-k8s-cluster.sh

--- a/config/vagrant/Vagrantfile
+++ b/config/vagrant/Vagrantfile
@@ -28,9 +28,15 @@ Vagrant.configure('2') do |config|
     # Triggers reload to setup docker rootless permissions.
     k8shost.vm.provision :reload
 
-    # Configures kubernetes.
+    # Download KIND and Kubectl/OC binaries
     k8shost.vm.provision 'shell',
                          path: 'scripts/bootstrap-cluster.sh',
                          privileged: false
+    
+    # Build the KIND cluster and install the resources
+    k8shost.vm.provision 'shell',
+                         inline: 'cd partner; make rebuild-cluster'
+    k8shost.vm.provision 'shell',
+                         inline: 'cd partner; make install'
   end
 end

--- a/config/vagrant/scripts/bootstrap-cluster.sh
+++ b/config/vagrant/scripts/bootstrap-cluster.sh
@@ -18,8 +18,3 @@ curl -Lo oc.tar.gz "${OC_DL_URL}"
 tar -xvf oc.tar.gz
 chmod +x oc kubectl
 sudo cp oc kubectl /usr/bin/.
-
-# create cluster
-cd partner || exit 1
-make rebuild-cluster
-make install

--- a/scripts/deploy-k8s-cluster.sh
+++ b/scripts/deploy-k8s-cluster.sh
@@ -5,10 +5,9 @@ kind delete cluster
 # Kind base with kindnetcni and ipv4/ipv6
 kind create cluster --config=config/k8s-cluster/config.yaml
 
-# download the calico YAML and change the image source to quay
-curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml -o temp-calico.yaml
-sed -i 's/docker.io/quay.io/g' temp-calico.yaml
+# Download the calico YAML and change the image source to quay
+curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml |
+	sed s/docker.io/quay.io/g >temp-calico.yaml
 
-# deploy calico (not needed but more feature rich - for future use)
+# Deploy calico (not needed but more feature rich - for future use)
 oc create -f temp-calico.yaml
-

--- a/scripts/deploy-k8s-cluster.sh
+++ b/scripts/deploy-k8s-cluster.sh
@@ -5,6 +5,10 @@ kind delete cluster
 # Kind base with kindnetcni and ipv4/ipv6
 kind create cluster --config=config/k8s-cluster/config.yaml
 
+# download the calico YAML and change the image source to quay
+curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml -o temp-calico.yaml
+sed -i 's/docker.io/quay.io/g' temp-calico.yaml
+
 # deploy calico (not needed but more feature rich - for future use)
-oc create -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico.yaml
+oc create -f temp-calico.yaml
 

--- a/scripts/deploy-multus-network.sh
+++ b/scripts/deploy-multus-network.sh
@@ -30,6 +30,7 @@ then
 
   # Install macvlan and other default plugins
   echo "## install CNIs"
+  sed 's/alpine/quay.io\/jitesoft\/alpine:latest/g' temp/multus-cni/e2e/cni-install.yml -i
   kubectl create -f temp/multus-cni/e2e/cni-install.yml
   kubectl -n kube-system wait --for=condition=ready -l name="cni-plugins" pod --timeout="$TNF_DEPLOYMENT_TIMEOUT"
 


### PR DESCRIPTION
Changes:
- Added some `bootstrap-*-fedora-local` Make paths to help with running the scripts used to build the kind cluster.
- Removed the `make rebuild-cluster/make install` from the bootstrap-cluster.sh and moved them into calls from the Vagrantfile.
- Update calico to [v3.25.0](https://github.com/projectcalico/calico/releases/tag/v3.25.0)
- Using `sed`, replacing images that come from Dockerhub with images that get pulled from Quay to avoid the rate limit problem.  Replaces alpine images with: https://quay.io/repository/jitesoft/alpine?tab=tags