### PR TITLE
Add dependabot for container images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/test-partner/"
+    schedule:
+      interval: "daily"

--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi:8.7
 
 ARG USERNAME=tnf-user
 ARG USER_UID=1000

--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi:8.7
 
 RUN \
     yum -y update && \


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/936

This doesn't include the Dockerfile linting from #936 rather just the dependabot setup and versioning changes.