### PR TITLE
Remove call to missing script

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR"/init-env.sh
 
 # Delete tnf, partner and operator and litmus
-./"$SCRIPT_DIR"/delete-partner-pods.sh
 ./"$SCRIPT_DIR"/delete-test-pods.sh
 ./"$SCRIPT_DIR"/delete-hpa.sh
 ./"$SCRIPT_DIR"/delete-test-crds.sh


### PR DESCRIPTION
`delete-partner-pods.sh` does not exist anymore.