### PR TITLE
Support OCP

### DIFF
--- a/.github/actions/create-local-ocp-test-infra-resources/action.yaml
+++ b/.github/actions/create-local-ocp-test-infra-resources/action.yaml
@@ -1,0 +1,44 @@
+name: create-local-ocp-test-infra-resources
+description: Creates `local-ocp-test-infra` OpenShift resources
+inputs:
+  default_namespace:
+    default: default
+  working_directory:
+    default: .
+  oc_namespace:
+    default: tnf
+  oc_pod_timeout:
+    description: "Timeout for the `oc wait` command"
+    default: 120s
+  put_deployment_name:
+    description: "The expected value of the test deployment name"
+    default: test
+  put_pod_label_app_statefulset:
+    description: "The expected value of the test statefulset's `app` label"
+    default: testss
+  put_pod_label_app_deployment:
+    description: "The expected value of the test deployment's `app` label"
+    default: testdp
+  put_pod_name_env_var:
+    description: "The environment variable the test pod's name will be saved to"
+    default: PUT_POD_NAME
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Create `local-test-infra` OpenShift resources
+      run: |
+        make install-ocp
+      working-directory: ${{ inputs.working_directory }}
+      shell: bash
+      env:
+        TNF_EXAMPLE_CNF_NAMESPACE: ${{ inputs.oc_namespace }}
+        DEFAULT_NAMESPACE: ${{ inputs.default_namespace }}
+
+    - name: Set the current context to use the correct TNF namespace
+      run: oc config set-context $(oc config current-context) --namespace=${{ inputs.oc_namespace }}
+      shell: bash
+
+    - name: Display all pods in all namespaces
+      run: oc get pods -A -o wide
+      shell: bash

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@
   install-prometheus
 
 # Deploys the partner and test pods and the operator
-install: clean
+install:
 	./scripts/fix-node-labels.sh
+	./scripts/deploy-calico.sh
 	./scripts/deploy-multus-network.sh
 	./scripts/deploy-resource-quota.sh
 	./scripts/deploy-test-pods.sh
@@ -19,8 +20,20 @@ install: clean
 	./scripts/deploy-community-operator.sh
 	./scripts/manage-service.sh deploy
 	./scripts/deploy-network-policies.sh
-	# ./scripts/install-prometheus-operator.sh
-	 ./scripts/deploy-operator-crd-scaling.sh
+	./scripts/deploy-operator-crd-scaling.sh
+
+install-ocp:
+	./scripts/fix-node-labels.sh
+	./scripts/deploy-multus-network.sh
+	./scripts/deploy-resource-quota.sh
+	./scripts/deploy-test-pods.sh
+	./scripts/deploy-statefulset-test-pods.sh
+	./scripts/deploy-pod-disruption-budget.sh
+	# ./scripts/deploy-test-crds.sh
+	./scripts/install-olm.sh
+	# ./scripts/deploy-community-operator.sh
+	./scripts/manage-service.sh deploy
+	./scripts/deploy-network-policies.sh
 
 # Bootstrap Fedora Machine Locally
 bootstrap-docker-fedora-local:
@@ -35,6 +48,7 @@ bootstrap-cluster-fedora-local:
 # creates a k8s cluster instance
 rebuild-cluster: delete-cluster
 	./scripts/deploy-k8s-cluster.sh
+	./scripts/deploy-calico.sh
 
 delete-cluster:
 	./scripts/delete-k8s-cluster.sh

--- a/scripts/delete-calico.sh
+++ b/scripts/delete-calico.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -x
+
+# Download the calico YAML and change the image source to quay
+curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml |
+	sed s/docker.io/quay.io/g >temp-calico.yaml
+
+# Delete calico (not needed but more feature rich - for future use)
+oc delete -f temp-calico.yaml
+rm temp-calico.yaml

--- a/scripts/deploy-calico.sh
+++ b/scripts/deploy-calico.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -x
+
+# Download the calico YAML and change the image source to quay
+curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml |
+	sed s/docker.io/quay.io/g >temp-calico.yaml
+
+# Deploy calico (not needed but more feature rich - for future use)
+oc create -f temp-calico.yaml
+rm temp-calico.yaml

--- a/scripts/deploy-k8s-cluster.sh
+++ b/scripts/deploy-k8s-cluster.sh
@@ -3,10 +3,3 @@ set -x
 
 # Kind base with kindnetcni and ipv4/ipv6
 kind create cluster --config=config/k8s-cluster/config.yaml
-
-# Download the calico YAML and change the image source to quay
-curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml |
-	sed s/docker.io/quay.io/g >temp-calico.yaml
-
-# Deploy calico (not needed but more feature rich - for future use)
-oc create -f temp-calico.yaml

--- a/scripts/deploy-multus-network.sh
+++ b/scripts/deploy-multus-network.sh
@@ -62,5 +62,5 @@ then
 
   sleep 3
 else 
-  echo "Minukube not detected, Skipping Multus installation"
+  echo "OCP Cluster detected, Skipping Multus installation"
 fi

--- a/scripts/deploy-statefulset-test-pods.sh
+++ b/scripts/deploy-statefulset-test-pods.sh
@@ -11,6 +11,8 @@ mkdir -p ./temp
 REPLICAS=2
 # adjust replicas for possible SNO clusters
 NUM_NODES=$(oc get nodes --no-headers | wc -l)
+NUM_NODES="${NUM_NODES#"${NUM_NODES%%[![:space:]]*}"}"
+NUM_NODES="${NUM_NODES%"${NUM_NODES##*[![:space:]]}"}" 
 if [[ $NUM_NODES == 1 ]]; then
 	REPLICAS=1
 fi
@@ -21,7 +23,7 @@ oc apply --filename ./temp/rendered-local-statefulset-pod-under-test-template.ya
 rm ./temp/rendered-local-statefulset-pod-under-test-template.yaml
 sleep 3
 
-oc wait -l statefulset.kubernetes.io/pod-name=test-0 -n "$TNF_EXAMPLE_CNF_NAMESPACE" --for=condition=ready pod --timeout="$TNF_DEPLOYMENT_TIMEOUT"
+# oc wait -l statefulset.kubernetes.io/pod-name=test-0 -n "$TNF_EXAMPLE_CNF_NAMESPACE" --for=condition=ready pod --timeout="$TNF_DEPLOYMENT_TIMEOUT"
 
 # Wait if there is more than one replica
 if [[ $REPLICAS -gt 1 ]]; then

--- a/scripts/deploy-test-pods.sh
+++ b/scripts/deploy-test-pods.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 # Initialization
 SCRIPT_DIR=$(dirname "$0")
 
@@ -11,6 +13,8 @@ mkdir -p ./temp
 REPLICAS=2
 # adjust replicas for possible SNO clusters
 NUM_NODES=$(oc get nodes --no-headers | wc -l)
+NUM_NODES="${NUM_NODES#"${NUM_NODES%%[![:space:]]*}"}"
+NUM_NODES="${NUM_NODES%"${NUM_NODES##*[![:space:]]}"}"   
 if [[ $NUM_NODES == 1 ]]; then
     REPLICAS=1
 fi
@@ -20,4 +24,4 @@ cat ./test-target/local-pod-under-test.yaml | APP="testdp" RESOURCE_TYPE="Deploy
 oc apply --filename ./temp/rendered-local-pod-under-test-template.yaml
 rm ./temp/rendered-local-pod-under-test-template.yaml
 
-oc wait deployment test -n "$TNF_EXAMPLE_CNF_NAMESPACE" --for=condition=available --timeout="$TNF_DEPLOYMENT_TIMEOUT"
+# oc wait deployment test -n "$TNF_EXAMPLE_CNF_NAMESPACE" --for=condition=available --timeout="$TNF_DEPLOYMENT_TIMEOUT"

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -49,7 +49,7 @@ export ON_DEMAND_DEBUG_PODS="${ON_DEMAND_DEBUG_PODS:-true}"
 
 #Partner repo
 export TNF_PARTNER_REPO="${TNF_PARTNER_REPO:-quay.io/testnetworkfunction}"
-export TNF_DEPLOYMENT_TIMEOUT="${TNF_DEPLOYMENT_TIMEOUT:-240s}"
+export TNF_DEPLOYMENT_TIMEOUT="${TNF_DEPLOYMENT_TIMEOUT:-600s}"
 
 # Number of multus interfaces to create
 MULTUS_IF_NUM="${MULTUS_IF_NUM:-2}"
@@ -61,6 +61,11 @@ NET_NAME="mynet"
 # Checks for non-OCP cluster.
 oc version | grep Server >/dev/null ||
 	{ printf 'Non-OCP cluster.\n'; TNF_NON_OCP_CLUSTER=true; }
+
+if [[ "$OCP_CLUSTER_OVERRIDE" == "true" ]]; then
+  echo 'OCP_CLUSTER_OVERRIDE is set to true, forcing OCP cluster'
+  TNF_NON_OCP_CLUSTER=false
+fi
 
 # create Multus annotations
 create_multus_annotation(){


### PR DESCRIPTION
Fixes:
- Remove `clean` from the `install` Make path.
- Remove the `temp-calico.yaml` file from the calico install for general cleanup.
- Remove whitespace around `NUM_NODES` variables.
- Add `securityContext` fixes for deploying the test pods on OCP properly without warnings.