### PR TITLE
Fix cloning for crd-operator-scaling

### DIFF
--- a/scripts/delete-operator-crd-scaling.sh
+++ b/scripts/delete-operator-crd-scaling.sh
@@ -4,13 +4,17 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # shellcheck disable=SC1091 # Not following.
 source "$SCRIPT_DIR"/init-env.sh
+
+# clone the repo
 REPO_NAME=crd-operator-scaling
-CRD_SCALING_URL=https://github.com/test-network-function/$REPO_NAME.git
 rm -rf $REPO_NAME
-git clone $CRD_SCALING_URL
+git clone "$CRD_SCALING_URL" -b "$CRD_SCALING_TAG" || exit 1
+
 ## install the operator
 cd $REPO_NAME || exit 1
 ## uninstall the crd
 make uninstall
 make undeploy ignore-not-found=true
+
+# delete the repo after uninstalling
 rm -rf $REPO_NAME

--- a/scripts/deploy-operator-crd-scaling.sh
+++ b/scripts/deploy-operator-crd-scaling.sh
@@ -4,10 +4,12 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # shellcheck disable=SC1091 # Not following.
 source "$SCRIPT_DIR"/init-env.sh
-CRD_SCALING_URL=https://github.com/test-network-function/crd-operator-scaling.git
-CRD_SCALING_TAG=v0.0.2
-rm -rf crd-operator-scaling
-git clone $CRD_SCALING_URL -b $CRD_SCALING_TAG || exit 1
+
+# clone the repo
+REPO_NAME=crd-operator-scaling
+rm -rf $REPO_NAME
+git clone "$CRD_SCALING_URL" -b "$CRD_SCALING_TAG" || exit 1
+
 ## install the operator
 cd crd-operator-scaling || exit 1
 ## install the crd
@@ -30,5 +32,9 @@ for i in $(seq $NUM); do
 		--timeout=240s
 	exit
 done
+
+# delete the repo after installing
+rm -rf "$REPO_NAME"
+
 printf >&2 'Exit by timeout after %d seconds.\n' $((BIT * NUM))
 exit 1

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -18,6 +18,9 @@ export \
 	OPERATOR_IMAGE_FULL_NAME=$REGISTRY$DIRECTORY$OPERATOR_IMAGE \
 	SECRET_NAME=foo-cert-sec
 
+export CRD_SCALING_URL=https://github.com/test-network-function/crd-operator-scaling.git
+export CRD_SCALING_TAG=v0.0.2
+
 # Truncate registry pod name if more than 63 characters
 if [[ ${#OPERATOR_REGISTRY_POD_NAME_FULL} -gt 63 ]];then
     export OPERATOR_REGISTRY_POD_NAME=${OPERATOR_REGISTRY_POD_NAME_FULL: -63}


### PR DESCRIPTION
We were not cloning the correct tag during the `delete` script.  This could lead to some mismatches.