### PR TITLE
Split out the calico deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ bootstrap-cluster-fedora-local:
 # creates a k8s cluster instance
 rebuild-cluster: delete-cluster
 	./scripts/deploy-k8s-cluster.sh
+	./scripts/deploy-calico.sh
 
 delete-cluster:
 	./scripts/delete-k8s-cluster.sh

--- a/scripts/delete-calico.sh
+++ b/scripts/delete-calico.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -x
+
+# Download the calico YAML and change the image source to quay
+curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.1/manifests/calico.yaml |
+	sed s/docker.io/quay.io/g >temp-calico.yaml
+
+# Delete calico (not needed but more feature rich - for future use)
+oc delete -f temp-calico.yaml
+rm temp-calico.yaml

--- a/scripts/deploy-calico.sh
+++ b/scripts/deploy-calico.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -x
+
+# Download the calico YAML and change the image source to quay
+curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.1/manifests/calico.yaml |
+	sed s/docker.io/quay.io/g >temp-calico.yaml
+
+# Deploy calico
+oc create -f temp-calico.yaml
+rm temp-calico.yaml

--- a/scripts/deploy-k8s-cluster.sh
+++ b/scripts/deploy-k8s-cluster.sh
@@ -3,10 +3,3 @@ set -x
 
 # Kind base with kindnetcni and ipv4/ipv6
 kind create cluster --config=config/k8s-cluster/config.yaml
-
-# Download the calico YAML and change the image source to quay
-curl https://raw.githubusercontent.com/projectcalico/calico/v3.25.1/manifests/calico.yaml |
-	sed s/docker.io/quay.io/g >temp-calico.yaml
-
-# Deploy calico (not needed but more feature rich - for future use)
-oc create -f temp-calico.yaml


### PR DESCRIPTION
Should be no functional change, but I want to be able to individually create and delete the calico deployment.