### PR TITLE
Updated dependencies versions for debug & test partner dockerfiles.

### DIFF
--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 		make-1:4.2.1 \
 		openssh-8.0p1 \
 		openssh-clients-8.0p1 \
-		podman-3:4.2.0 \
+		podman-3:4.4.1 \
 		psmisc-23.1 \
 		wget-1.19.5 \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \

--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -2,9 +2,9 @@ FROM registry.access.redhat.com/ubi8/ubi:8.7 as podman-builder
 RUN \
 	dnf update --assumeyes --disableplugin=subscription-manager \
 	&& dnf install --assumeyes --disableplugin=subscription-manager \
-		git-2.31.1-3.el8_7 \
+		git-2.39.3 \
 		make-1:4.2.1-11.el8 \
-		golang-1.18.10-1.module+el8.7.0+18302+aa634922 \
+		golang-1.19.6 \
 		gpgme-devel-1.13.1-11.el8 \
 		libseccomp-devel-2.5.2-1.el8 \
 		libassuan-devel-2.5.1-3.el8 \


### PR DESCRIPTION
The debug and test partner image building has been failing recently in github CI jobs because of some dependencies not available any more.

![image](https://github.com/test-network-function/cnf-certification-test-partner/assets/87083379/4cb4498f-76d9-42dd-92af-37e61090e138)

**Upgrades**
- test-partner: podman upgraded to 4.4.1
- debug-partner: golang upgraded to 1.19.6, git to 2.39.3