### PR TITLE
Skip crd-operator-scaling operations if MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 	install-prometheus
 
 # Deploys the partner and test pods and the operator
-install: clean
+install:
 	./scripts/fix-node-labels.sh
 	./scripts/deploy-multus-network.sh
 	./scripts/deploy-resource-quota.sh
@@ -144,3 +144,6 @@ delete-services:
 
 deploy-test-crd-scaling-operator:
 	./scripts/deploy-operator-crd-scaling.sh
+
+lint:
+	shellcheck scripts/*.sh

--- a/scripts/delete-operator-crd-scaling.sh
+++ b/scripts/delete-operator-crd-scaling.sh
@@ -5,6 +5,12 @@ SCRIPT_DIR="$(dirname "$0")"
 # shellcheck disable=SC1091 # Not following.
 source "$SCRIPT_DIR"/init-env.sh
 
+# Skip the delete if MacOS
+if [[ "$(uname -s)" == "Darwin"* ]]; then
+  echo "Skipping operator crd scaling delete on MacOS"
+  exit 0
+fi
+
 # clone the repo
 REPO_NAME=crd-operator-scaling
 rm -rf $REPO_NAME

--- a/scripts/deploy-operator-crd-scaling.sh
+++ b/scripts/deploy-operator-crd-scaling.sh
@@ -5,6 +5,12 @@ SCRIPT_DIR="$(dirname "$0")"
 # shellcheck disable=SC1091 # Not following.
 source "$SCRIPT_DIR"/init-env.sh
 
+# Skip the install if MacOS
+if [[ "$(uname -s)" == "Darwin"* ]]; then
+  echo "Skipping operator crd scaling install on MacOS"
+  exit 0
+fi
+
 # clone the repo
 REPO_NAME=crd-operator-scaling
 rm -rf $REPO_NAME


### PR DESCRIPTION
* Remove the `clean` from `make install` as it's not needed.
* Add check for MacOS in the crd-operator-scaling repo operations since `kustomize` seems to be having a problem with native mac installs (for now).  Once this is fixed, we can remove the check.
* Add `make lint` to run shellcheck on the `scripts/` dir.