### PR TITLE
Change image in whereabouts daemonset

### DIFF
--- a/scripts/deploy-multus-network.sh
+++ b/scripts/deploy-multus-network.sh
@@ -39,7 +39,15 @@ then
   kubectl -n kube-system wait --for=condition=ready -l name="cni-plugins" pod --timeout="$TNF_DEPLOYMENT_TIMEOUT"
 
   # Install whereabouts at specific released version
-  git clone $WHEREABOUTS_GIT_URL --depth 1 -b v0.6.1
+  # git clone $WHEREABOUTS_GIT_URL --depth 1 -b v0.6.1
+  git clone $WHEREABOUTS_GIT_URL --depth 1
+  pushd whereabouts || exit
+  git checkout d15b4d5456ee910a81bf15e9e242a136823d22fd
+  popd || exit
+
+  # Replace the image in the daemonset-install.yaml
+  sed 's/whereabouts\/whereabouts:latest-amd64/whereabouts\/whereabouts:v0.6.1-amd64/g' whereabouts/doc/crds/daemonset-install.yaml -i
+
   oc apply \
     -f whereabouts/doc/crds/daemonset-install.yaml \
     -f whereabouts/doc/crds/whereabouts.cni.cncf.io_ippools.yaml \


### PR DESCRIPTION
The 0.6.1 tag of the whereabouts repo is incorrect, and needs to be replaced.

We have determined that the latest available commit `d15b4d5456ee910a81bf15e9e242a136823d22fd` is compatible with the 0.6.1-amd64 image.

https://github.com/k8snetworkplumbingwg/whereabouts/blob/v0.6.1/doc/crds/daemonset-install.yaml#LL104C57-L104C69