### PR TITLE
Add 'release' section to image deploy YAML

### DIFF
--- a/.github/workflows/debug-partner-image.yaml
+++ b/.github/workflows/debug-partner-image.yaml
@@ -8,9 +8,8 @@ on:
   # around 10-30 minutes.
   schedule:
     - cron: '0 5 * * *'
-  push:
-    tags:
-      - v*
+  release:
+    types: [published]
   workflow_dispatch:
 defaults:
   run:


### PR DESCRIPTION
Removes the push/tags flow and adds release.