### PR TITLE
Install OLM from source

### DIFF
--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -21,9 +21,11 @@ else
   echo "operator-sdk was found in the path, no need to install it"
 fi
 
-# Install OLM
-operator-sdk olm uninstall
-operator-sdk olm install --version=v0.24.0
+curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.25.0/install.sh -o install.sh
+chmod +x install.sh
+./install.sh v0.25.0
+rm install.sh
+
 # Wait for all OLM pods to be ready
 kubectl wait --for=condition=ready pod --all=true -nolm --timeout="$TNF_DEPLOYMENT_TIMEOUT"
 sleep 5


### PR DESCRIPTION
There seems to be this problem: https://github.com/operator-framework/operator-sdk/issues/5951

Where we are getting the same error: `FATA[0011] Failed to uninstall OLM: no matches for kind "OLMConfig" in version "operators.coreos.com/v1"`