### PR TITLE
Add service account for test pod

### DIFF
--- a/scripts/deploy-test-pods.sh
+++ b/scripts/deploy-test-pods.sh
@@ -19,6 +19,7 @@ fi
 
 # shellcheck disable=SC2002 # Useless cat.
 cat ./test-target/local-pod-under-test.yaml | APP="testdp" RESOURCE_TYPE="Deployment" MULTUS_ANNOTATION=$MULTUS_ANNOTATION REPLICAS=$REPLICAS "$SCRIPT_DIR"/mo > ./temp/rendered-local-pod-under-test-template.yaml
+oc apply --filename ./test-target/test-service-account.yaml
 oc apply --filename ./temp/rendered-local-pod-under-test-template.yaml
 rm ./temp/rendered-local-pod-under-test-template.yaml
 

--- a/test-target/local-pod-under-test.yaml
+++ b/test-target/local-pod-under-test.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 30
       automountServiceAccountToken: false
+      serviceAccountName: test-pod-sa
       containers:
         - image: quay.io/testnetworkfunction/cnf-test-partner:latest
           imagePullPolicy: IfNotPresent

--- a/test-target/test-service-account.yaml
+++ b/test-target/test-service-account.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-pod-sa
+  namespace: tnf


### PR DESCRIPTION
Applies a service account `test-pod-sa` in the `tnf` namespace so the test pods can use it and pass the tests.

Related to: https://github.com/test-network-function/cnf-certification-test/pull/1197