### PR TITLE
Update podman to v4.6.0

### DIFF
--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.7
+FROM registry.access.redhat.com/ubi8/ubi:8.8-854
 ARG USERNAME=tnf-user
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID

--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.7 as podman-builder
+FROM registry.access.redhat.com/ubi8/ubi:8.8-854 as podman-builder
 # hadolint ignore=DL3041
 RUN \
 	dnf update --assumeyes --disableplugin=subscription-manager \
@@ -14,10 +14,10 @@ RUN \
 	&& git clone https://github.com/containers/podman.git
 WORKDIR /podman
 RUN \
-	git checkout v4.5.1 \
+	git checkout v4.6.0 \
 	&& make
 
-FROM registry.access.redhat.com/ubi8/ubi:8.7
+FROM registry.access.redhat.com/ubi8/ubi:8.8-854
 # hadolint ignore=DL3041
 RUN \
 	dnf update --assumeyes --disableplugin=subscription-manager \


### PR DESCRIPTION
https://github.com/containers/podman/releases/tag/v4.6.0

Bonus - updated the UBI8 image to match the cnf-certification-test repo.  The dependabot still doesn't like two Dockerfiles living in the same repo.