### PR TITLE
Delete 'standard' storageclass at end of install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ install:
 	./scripts/manage-service.sh deploy
 	./scripts/deploy-network-policies.sh
 	./scripts/deploy-operator-crd-scaling.sh
+	./scripts/delete-standard-storageclass.sh
 
 # Bootstrap Docker (Fedora)
 bootstrap-docker-fedora-local:

--- a/scripts/delete-standard-storageclass.sh
+++ b/scripts/delete-standard-storageclass.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Initialization
+SCRIPT_DIR=$(dirname "$0")
+
+# shellcheck disable=SC1091 # Not following.
+source "$SCRIPT_DIR"/init-env.sh
+
+oc delete storageclass standard --ignore-not-found


### PR DESCRIPTION
The `standard` storageclass that Kind creates by default is not needed and causes problems when running QE against a Kind cluster bootstrapped with `make install`.