### PR TITLE
Add storageclass delete to 'make rebuild-cluster'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ rebuild-cluster: delete-cluster
 	./scripts/deploy-k8s-cluster.sh
 	./scripts/deploy-calico.sh
 	./scripts/preload-images.sh
+	./scripts/delete-standard-storageclass.sh
 
 delete-cluster:
 	./scripts/delete-k8s-cluster.sh


### PR DESCRIPTION
Follow up to #318, add the storageclass cleanup script to the `make rebuild-cluster` path.

@jmontesi pointed out that we don't need to install all of the partner resources as part of the QE kind cluster testing so this is the only thing we need to get it working.