### PR TITLE
Add 'worker-cnf' labels to workers

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -65,6 +65,17 @@ jobs:
       PFLT_DOCKERCONFIG: '/home/runner/.docker/config'
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:

--- a/scripts/fix-node-labels.sh
+++ b/scripts/fix-node-labels.sh
@@ -8,4 +8,5 @@ source "$SCRIPT_DIR"/init-env.sh
 if $TNF_NON_OCP_CLUSTER; then
 	echo "non ocp cluster detected, applying worker labels on all nodes"
 	oc get nodes -oname | xargs -I{} oc label {} node-role.kubernetes.io/worker=worker --overwrite
+	oc get nodes -oname | xargs -I{} oc label {} node-role.kubernetes.io/worker-cnf= --overwrite
 fi


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnfcert-tests-verification/pull/393

Make sure that all workers in Kind are labeled with `node-role.kubernetes.io/worker-cnf: ""`.

![image](https://github.com/test-network-function/cnf-certification-test-partner/assets/4563082/a59ac38e-58e4-4662-8483-c2cdcf07b263)
