### PR TITLE
Add more images to preloading script

### DIFF
--- a/scripts/preload-images.sh
+++ b/scripts/preload-images.sh
@@ -17,3 +17,18 @@ kind load docker-image $HTTPD_IMAGE
 # Preload hazelcast-platform-operator
 docker pull "$COMMUNITY_OPERATOR_IMAGEREPO"/"$COMMUNITY_OPERATOR_BASE":"$COMMUNITY_OPERATOR_IMAGEVERSION"
 kind load docker-image "$COMMUNITY_OPERATOR_IMAGEREPO"/"$COMMUNITY_OPERATOR_BASE":"$COMMUNITY_OPERATOR_IMAGEVERSION"
+
+# Preload test-partner image since we use that for testing
+PARTNER_IMAGE=quay.io/testnetworkfunction/cnf-test-partner:latest
+docker pull $PARTNER_IMAGE
+kind load docker-image $PARTNER_IMAGE
+
+# Preload debug-partner image for the daemonset
+DEBUG_PARTNER_IMAGE=quay.io/testnetworkfunction/debug-partner:latest
+docker pull $DEBUG_PARTNER_IMAGE
+kind load docker-image $DEBUG_PARTNER_IMAGE
+
+# Preload crd-operator-scaling image
+CRD_SCALING_IMAGE=quay.io/testnetworkfunction/crd-operator-scaling:${CRD_SCALING_TAG}
+docker pull "$CRD_SCALING_IMAGE"
+kind load docker-image "$CRD_SCALING_IMAGE"


### PR DESCRIPTION
Adds the cnf-test-partner, debug-partner, and crd-operator-scaling images to the script to preload onto the Kind nodes.  This will prevent all 4 of the workers having to pull images and hopefully reduce our footprint and increase speed.