### PR TITLE
Re-enable shfmt; fix shell script

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -38,8 +38,8 @@ jobs:
           SHELLCHECK_OPTS: --external-sources
         with:
           ignore_names: mo
-      #- uses: mfinelli/setup-shfmt@v2
-      #- run: shfmt -d scripts/*.sh
+      - uses: mfinelli/setup-shfmt@v2
+      - run: shfmt -d scripts/*.sh
       - uses: crate-ci/typos@master
       - uses: ibiqlik/action-yamllint@v3
         with:

--- a/scripts/deploy-cr-scale-operator.sh
+++ b/scripts/deploy-cr-scale-operator.sh
@@ -36,5 +36,3 @@ popd || exit 1
 
 log_info "Removing cr operator checkout folder ${CR_SCALE_OPERATOR_DIR}."
 rm -rf $CR_SCALE_OPERATOR_DIR
-
-


### PR DESCRIPTION
`scripts/deploy-cr-scale-operator.sh` had two extra lines at the end of the file which shfmt wasn't happy about.