### PR TITLE
Update Go to v1.21.0

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -76,10 +76,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - name: Set up Go 1.20
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.7
+          go-version: 1.21.0
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 
 # Install Go binary
 ENV \
-	GO_BIN_TAR=go1.20.7.linux-amd64.tar.gz \
+	GO_BIN_TAR=go1.21.0.linux-amd64.tar.gz \
 	GO_DL_URL=https://golang.org/dl \
 	GOPATH=/root/go \
 	TEMP_DIR=/tmp

--- a/testapp/go.mod
+++ b/testapp/go.mod
@@ -1,3 +1,3 @@
 module main
 
-go 1.20
+go 1.21


### PR DESCRIPTION
https://go.dev/doc/go1.21

Related to: https://github.com/test-network-function/cnf-certification-test/pull/1344