### PR TITLE
Add script for removing control-plane taint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ rebuild-cluster: delete-cluster
 	./scripts/deploy-calico.sh
 	./scripts/preload-images.sh
 	./scripts/delete-standard-storageclass.sh
+	./scripts/remove-control-plane-taint.sh
 
 delete-cluster:
 	./scripts/delete-k8s-cluster.sh

--- a/scripts/remove-control-plane-taint.sh
+++ b/scripts/remove-control-plane-taint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Script to remove the control plane taint from the control-plane nodes
+
+# Get the list of control-plane nodes
+CONTROL_PLANE_NODES=$(kubectl get nodes --selector=node-role.kubernetes.io/control-plane -o name)
+MASTER_NODES=$(kubectl get nodes --selector=node-role.kubernetes.io/master -o name)
+
+# Remove the control-plane taint from the control-plane nodes
+for node in $CONTROL_PLANE_NODES; do
+	kubectl taint nodes "$node" node-role.kubernetes.io/control-plane:NoSchedule-
+done
+
+# Remove the master taint from the master nodes (deprecated)
+for node in $MASTER_NODES; do
+	kubectl taint nodes "$node" node-role.kubernetes.io/master:NoSchedule-
+done


### PR DESCRIPTION
Just get ahead of the ball and remove the control plane taint during the Kind cluster spin up instead of worrying about it in QE.