### PR TITLE
Add a single worker Kind config and deployment method

### DIFF
--- a/.github/workflows/cnf-test-partner-image.yaml
+++ b/.github/workflows/cnf-test-partner-image.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: edcdavid/free-disk-space@main
+        uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/debug-partner-image.yaml
+++ b/.github/workflows/debug-partner-image.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: edcdavid/free-disk-space@main
+        uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/local-test-infra.yaml
+++ b/.github/workflows/local-test-infra.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: edcdavid/free-disk-space@main
+        uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: edcdavid/free-disk-space@main
+        uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
           android: true

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,14 @@ rebuild-cluster: delete-cluster
 	./scripts/delete-standard-storageclass.sh
 	./scripts/remove-control-plane-taint.sh
 
+# Creates a k8s cluster with a single worker
+rebuild-cluster-single-worker: delete-cluster
+	./scripts/deploy-k8s-cluster-single-worker.sh
+	./scripts/deploy-calico.sh
+	./scripts/preload-images.sh
+	./scripts/delete-standard-storageclass.sh
+	./scripts/remove-control-plane-taint.sh
+
 delete-cluster:
 	./scripts/delete-k8s-cluster.sh
 

--- a/config/k8s-cluster/single-worker.yaml
+++ b/config/k8s-cluster/single-worker.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: dual
+  disableDefaultCNI: true
+  apiServerAddress: "0.0.0.0"
+  apiServerPort: 6443
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+  - role: worker
+    image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72

--- a/scripts/deploy-k8s-cluster-single-worker.sh
+++ b/scripts/deploy-k8s-cluster-single-worker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -x
+
+# Kind base with kindnetcni and ipv4/ipv6
+kind create cluster --config=config/k8s-cluster/single-worker.yaml


### PR DESCRIPTION
Add a similar make path for deploying a single worker cluster (2 nodes, worker and controlplane).