### PR TITLE
Add 'default' namespace to network policy

### DIFF
--- a/scripts/delete-network-policies.sh
+++ b/scripts/delete-network-policies.sh
@@ -14,4 +14,5 @@ mkdir -p ./temp
 # shellcheck disable=SC2002 # Useless cat.
 cat ./test-target/pod-to-pod-np.yaml | TNF_EXAMPLE_CNF_NAMESPACE=$TNF_EXAMPLE_CNF_NAMESPACE "$SCRIPT_DIR"/mo >./temp/rendered-pod-to-pod-np.yaml
 oc delete --filename ./temp/rendered-pod-to-pod-np.yaml --namespace "$TNF_EXAMPLE_CNF_NAMESPACE" --ignore-not-found
+oc delete --filename ./temp/rendered-pod-to-pod-np.yaml --namespace default --ignore-not-found
 rm ./temp/rendered-pod-to-pod-np.yaml

--- a/scripts/deploy-network-policies.sh
+++ b/scripts/deploy-network-policies.sh
@@ -21,4 +21,7 @@ cat ./test-target/pod-to-pod-np.yaml | TNF_EXAMPLE_CNF_NAMESPACE=$TNF_EXAMPLE_CN
 
 # Apply policies to allow pod-to-pod communication (aka make the ping test work)
 oc apply --filename ./temp/rendered-pod-to-pod-np.yaml --namespace "$TNF_EXAMPLE_CNF_NAMESPACE"
+
+# Apply the same pod-to-pod YAML to the default namespace
+oc apply --filename ./temp/rendered-pod-to-pod-np.yaml --namespace default
 rm ./temp/rendered-pod-to-pod-np.yaml


### PR DESCRIPTION
Allow traffic ingress and egress from the `default` namespace.

This fixes problems seen in:
- https://github.com/test-network-function/cnf-certification-test/pull/1516
- https://github.com/test-network-function/cnf-certification-test/pull/1518

cc @shirmoran @greyerof 