### PR TITLE
Skip preloading if running on github-hosted runners

### DIFF
--- a/.github/actions/start-k8s-cluster/action.yaml
+++ b/.github/actions/start-k8s-cluster/action.yaml
@@ -28,6 +28,8 @@ runs:
       run: make rebuild-cluster
       working-directory: ${{ inputs.working_directory }}
       shell: bash
+      env:
+        SKIP_PRELOAD_IMAGES: true
 
     # Wait for all pods to be ready
     - name: Wait for all pods ready

--- a/Makefile
+++ b/Makefile
@@ -60,16 +60,16 @@ bootstrap-cluster:
 # Creates a k8s cluster instance
 rebuild-cluster: delete-cluster
 	./scripts/deploy-k8s-cluster.sh
-	./scripts/deploy-calico.sh
 	./scripts/preload-images.sh
+	./scripts/deploy-calico.sh
 	./scripts/delete-standard-storageclass.sh
 	./scripts/remove-control-plane-taint.sh
 
 # Creates a k8s cluster with a single worker
 rebuild-cluster-single-worker: delete-cluster
 	./scripts/deploy-k8s-cluster-single-worker.sh
-	./scripts/deploy-calico.sh
 	./scripts/preload-images.sh
+	./scripts/deploy-calico.sh
 	./scripts/delete-standard-storageclass.sh
 	./scripts/remove-control-plane-taint.sh
 

--- a/scripts/preload-images.sh
+++ b/scripts/preload-images.sh
@@ -6,6 +6,12 @@ SCRIPT_DIR=$(dirname "$0")
 # shellcheck disable=SC1091 # Not following.
 source "$SCRIPT_DIR"/init-env.sh
 
+# check if SKIP_PRELOAD_IMAGES is set to true
+if [[ "$SKIP_PRELOAD_IMAGES" == "true" ]]; then
+	echo "Skipping image preloading"
+	exit 0
+fi
+
 # Exit script on error
 set -e
 


### PR DESCRIPTION
In an attempt to speed up the cluster spawning process on github-hosted runners, I'm adding an environment flag to skip the preloading of images.  This is only needed essentially for the QE self-hosted runners.