### PR TITLE
Dockerfile for debug partner: build podman with ubi8.

### DIFF
--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.3-1476 as podman-builder
+# IMPORTANT: podman must be build from ubi8.x only. Do not upgrade it to ubi9.
+FROM registry.access.redhat.com/ubi8/ubi:8.9-1107.1706791207 as podman-builder
+
 # hadolint ignore=DL3041
 RUN \
 	dnf update --assumeyes --disableplugin=subscription-manager \


### PR DESCRIPTION
Podman must be always built with ubi8, since it's going to be used as a workaround for platform-alteration-base-image test case when running in clusters with OCP versions 4.12.z or lower only. The CoreOS of those OCPs are based on RHEL 8.x.

See https://access.redhat.com/articles/6907891