### PR TITLE
ubuntu bootstrapping: modify docker cfg instead of full rewrite.

### DIFF
--- a/config/vagrant/scripts/bootstrap-docker-ubuntu.sh
+++ b/config/vagrant/scripts/bootstrap-docker-ubuntu.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 
-# update docker config
-sudo bash -c 'cat <<- EOF > /etc/docker/daemon.json
-{
-  "ipv6": true,
-  "fixed-cidr-v6": "2001:db8:1::/64"
-}
-EOF'
+# update docker config to include ipv6 support
+jq '. +={"ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64"}' < /etc/docker/daemon.json > /tmp/new-docker-daemon.json
+sudo cp /tmp/new-docker-daemon.json /etc/docker/daemon.json
+rm /tmp/new-docker-daemon.json
 
 # restart docker
 sudo systemctl restart docker

--- a/config/vagrant/scripts/bootstrap-docker-ubuntu.sh
+++ b/config/vagrant/scripts/bootstrap-docker-ubuntu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # update docker config to include ipv6 support
-jq '. +={"ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64"}' < /etc/docker/daemon.json > /tmp/new-docker-daemon.json
+jq '. +={"ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64"}' /etc/docker/daemon.json > /tmp/new-docker-daemon.json
 sudo cp /tmp/new-docker-daemon.json /etc/docker/daemon.json
 rm /tmp/new-docker-daemon.json
 


### PR DESCRIPTION
Adding ipv6 support for docker bootstrapping on ubuntu was rewriting the full docker daemon.json config file.

This change just adds (or overwrites) the required fields to add ipv6 support.

This will allow us moving the [switching docker storage to /mnt](https://github.com/test-network-function/cnf-certification-test/pull/1857) step in our github ci workflows right at the beginning on each job as the first step, instead of doing it after this script has overwritten the docker config.