### PR TITLE
Stop and fail the installation of the test target on hazelcast failure

### DIFF
--- a/scripts/deploy-community-operator.sh
+++ b/scripts/deploy-community-operator.sh
@@ -22,7 +22,7 @@ fi
 # shellcheck disable=SC2143 # Use ! grep -q.
 if [[ -z "$(oc get packagemanifests | grep hazelcast 2>/dev/null)" ]]; then
 	echo "hazelcast package was not found in the catalog, skipping installation"
-	exit 0
+	exit 1
 fi
 echo "hazelcast package found, starting installation"
 


### PR DESCRIPTION
If the installation of the hazelcast operator fails the script should return an error code so that the CI reports this step as failed.