### PR TITLE
Update operator-sdk to v1.34.1

### DIFF
--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -16,7 +16,7 @@ else
 	export ARCH OS
 
 	## Download executable
-	export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.34.0
+	export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.34.1
 	curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_"${OS}"_"${ARCH}"
 
 	## Download the auth key


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/1915