### PR TITLE
Revert "Update podman to v5.0.0 (#414)"

### DIFF
--- a/test-partner/Dockerfile.debug-partner
+++ b/test-partner/Dockerfile.debug-partner
@@ -16,7 +16,7 @@ RUN \
 	&& git clone https://github.com/containers/podman.git
 WORKDIR /podman
 RUN \
-	git checkout v5.0.0 \
+	git checkout v4.9.3 \
 	&& make
 
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1610


### PR DESCRIPTION
This reverts commit 8fdf8613307c38a17e77684ce2130fd97a26cdd6.

Podman v5.0.0 won't work in RHEL8-based OCPs (4.12.x). We need to revert this change until a better solution is implemented in the CNF CertSuite or newer 4.12.x versions are fully compatible with podman v5.x.