### PR TITLE
Send alert msgs to the dev team's slack channel.

### DIFF
--- a/.github/actions/slack-webhook-sender/action.yml
+++ b/.github/actions/slack-webhook-sender/action.yml
@@ -1,0 +1,34 @@
+name: slack-webhook-sender
+description: 'Sends a slack message plus some more workflow job related fields to a slack webhook endpoint.'
+inputs:
+  message:
+    description: 'Text that will be send in the json .message field.'
+    required: true
+    default: 'Hello, world!'
+  slack_webhook:
+    description: 'Slack webhook where the data will be posted.'
+    required: true
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post message data to slack's webhook url.
+      shell: bash
+      env:
+        MESSAGE: ${{ inputs.message }}
+        REPO_URL: 'https://github.com/${{ github.repository }}'
+        COMMIT_URL: 'https://github.com/${{ github.repository }}/commit/${{ github.sha }}'
+        JOB_URL: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}'
+        ATTEMPT: ${{ github.run_attempt }}
+      run: |
+          data="{                              \
+            \"message\"   : \"${MESSAGE}\",    \
+            \"repo_url\"  : \"${REPO_URL}\",   \
+            \"job_url\"   : \"${JOB_URL}\",    \
+            \"commit_url\": \"${COMMIT_URL}\", \
+            \"attempt\"   : \"${ATTEMPT}\"     \
+          }"
+
+          echo "Sending alert message data to slack webhook: $(echo $data | jq)"
+          curl -X POST --data "${data}" -H 'Content-type: application/json; charset=UTF-8' '${{ inputs.slack_webhook }}'

--- a/.github/workflows/cnf-test-partner-image.yaml
+++ b/.github/workflows/cnf-test-partner-image.yaml
@@ -77,12 +77,7 @@ jobs:
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}
-        env:
-          COMMIT_SHA: ${{ github.sha }}
-          JOB_RUN_ID: ${{ github.run_id }}
-          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
-          GITHUB_REPO: 'https://github.com/${{ github.repository }}'
-        run: |
-          curl -X POST --data "{
-            \"text\": \"🚨⚠️  Failed to create partner image version \`$IMAGE_TAG\` from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
-          }" -H 'Content-type: application/json; charset=UTF-8' '${{ secrets.GCHAT_WEBHOOK_URL }}'
+        uses: ./.github/actions/slack-webhook-sender
+        with:
+          message: 'Failed to create debug parter image version ${{ env.IMAGE_TAG }}'
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'

--- a/.github/workflows/debug-partner-image.yaml
+++ b/.github/workflows/debug-partner-image.yaml
@@ -87,12 +87,7 @@ jobs:
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}
-        env:
-          COMMIT_SHA: ${{ github.sha }}
-          JOB_RUN_ID: ${{ github.run_id }}
-          JOB_RUN_ATTEMPT: ${{ github.run_attempt }}
-          GITHUB_REPO: 'https://github.com/${{ github.repository }}'
-        run: |
-          curl -X POST --data "{
-            \"text\": \"🚨⚠️  Failed to create debug parter image version \`$IMAGE_TAG\` from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
-          }" -H 'Content-type: application/json; charset=UTF-8' '${{ secrets.GCHAT_WEBHOOK_URL }}'
+        uses: ./.github/actions/slack-webhook-sender
+        with:
+          message: 'Failed to create debug parter image version ${{ env.IMAGE_TAG }}'
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'


### PR DESCRIPTION
Updated github workflows to send alert msgs to the dev team's slack channel, similar to
https://github.com/test-network-function/cnf-certification-test/pull/1929