### PR TITLE
Fix URL from old repo

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -41,7 +41,7 @@ jobs:
           ignore_names: mo
       - uses: mfinelli/setup-shfmt@v3
       - run: shfmt -d scripts/*.sh
-      - uses: crate-ci/typos@master
+      # - uses: crate-ci/typos@master # Temporarily disabled
       - uses: ibiqlik/action-yamllint@v3
         with:
           config_data: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 This repository contains two main sections:
 
 * test-partner:  Partner debug pods definition for use on a k8s CNF Certification cluster. Used to run platform and networking tests.
-* test-target:  A trivial example CNF (including a replicaset/deployment, a CRD and an operator), primarily intended to be used to run [test-network-function](https://github.com/test-network-function/test-network-function) test suites on a development machine.
+* test-target:  A trivial example CNF (including a replicaset/deployment, a CRD and an operator), primarily intended to be used to run [test-network-function](https://github.com/test-network-function/cnf-certification-test) test suites on a development machine.
 
 Together, they make up the basic infrastructure required for "testing the tester". The partner debug pod is always required for platform tests and networking tests.
 
@@ -190,7 +190,7 @@ make install
 ```
 
 This will create a PUT named "test" in `TNF_EXAMPLE_CNF_NAMESPACE` [namespace](#namespace) and Debug Daemonset named "debug". The
-example `tnf_config.yml` in [`test-network-function`](https://github.com/test-network-function/test-network-function)
+example `tnf_config.yml` in [`test-network-function`](https://github.com/test-network-function/cnf-certification-test)
 will use this local infrastructure by default.
 
 Note that this command also creates OT and CRD resources.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 
 This folder is going to house some example YAMLs that will make the test suite fail if applied to a cluster.  Not all test suites have an example to show but more examples can be added in the future.
 
-Please refer to the [CATALOG](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md) for more information about the examples and how they affect the test suite's results.
+Please refer to the [CATALOG](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md) for more information about the examples and how they affect the test suite's results.
 
 ## Examples by Test Suite
 
@@ -11,94 +11,94 @@ Please find an example below that ties to a specific test case you are intereste
 
 ### accesscontrol
 
-* [cluster-role-bindings](examples/accesscontrol/clusterRoleBinding.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#cluster-role-bindings)
+* [cluster-role-bindings](examples/accesscontrol/clusterRoleBinding.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#cluster-role-bindings)
 
 Creates necessary cluster role, role binding, service account, and pod that causes a failure in the `accesscontrol` suite of tests because the rolebinding cannot cross namespaces.
 
-* [host-resource (host-port)](examples/accesscontrol/hostPortPod.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#host-resource)
-* [host-resource (ipc-lock)](examples/accesscontrol/ipcLockPod.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#host-resource)
-* [host-resource (net-admin)](examples/accesscontrol/netAdminPod.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#host-resource)
-* [host-resource (net-raw)](examples/accesscontrol/netRawPod.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#host-resource)
-* [host-resource (sys-admin)](examples/accesscontrol/sysAdminPod.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#host-resource)
+* [host-resource (host-port)](examples/accesscontrol/hostPortPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
+* [host-resource (ipc-lock)](examples/accesscontrol/ipcLockPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
+* [host-resource (net-admin)](examples/accesscontrol/netAdminPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
+* [host-resource (net-raw)](examples/accesscontrol/netRawPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
+* [host-resource (sys-admin)](examples/accesscontrol/sysAdminPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#host-resource)
 
-* namespace (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#namespace)
+* namespace (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#namespace)
 
-* [pod-automount-service-account-token](examples/accesscontrol/serviceAccountTokenPod.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-automount-service-account-token)
+* [pod-automount-service-account-token](examples/accesscontrol/serviceAccountTokenPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-automount-service-account-token)
 
-* [pod-role-bindings](examples/accesscontrol/podRoleBinding.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-role-bindings)
+* [pod-role-bindings](examples/accesscontrol/podRoleBinding.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-role-bindings)
 
 Creates necessary role, role binding, service account, and pod that causes a failure in the `accesscontrol` suite of tests because the rolebinding cannot cross namespaces.
 
-* [pod-service-account](examples/accesscontrol/serviceAccountPod.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-service-account)
+* [pod-service-account](examples/accesscontrol/serviceAccountPod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-service-account)
 
 ### affiliated-certification
 
 No examples to show (yet)…
 
-* container-is-certified (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#container-is-certified)
-* operator-is-certified (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#operator-is-certified)
+* container-is-certified (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#container-is-certified)
+* operator-is-certified (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#operator-is-certified)
 
 ### lifecycle
 
 Note: We might need the following flag set in the environment in which you are testing these YAMLs to avoid any draining, cluster-intrusive issues, etc.
 `export TNF_NON_INTRUSIVE_ONLY=true`
 
-* [container-shutdown (prestop)](examples/lifecycle/preStop.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#container-shutdown)
+* [container-shutdown (prestop)](examples/lifecycle/preStop.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#container-shutdown)
 
 Creates a pod without a lifecycle.preStop defined that will cause a failure with this test suite.
 
-* deployment-scaling (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#deployment-scaling)
+* deployment-scaling (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#deployment-scaling)
 
-* [image-pull-policy](examples/lifecycle/imagePullPolicy.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#image-pull-policy)
+* [image-pull-policy](examples/lifecycle/imagePullPolicy.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#image-pull-policy)
 
 Image in this pod has a pull policy of 'Always' which is incorrect.
 
-* [pod-termination-grace-period](examples/lifecycle/terminationGracePeriod.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-termination-grace-period)
+* [pod-termination-grace-period](examples/lifecycle/terminationGracePeriod.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-termination-grace-period)
 
 Creates a pod without a terminationGracePeriod set correctly.
 
-* [pod-high-availability](examples/lifecycle/highAvailability.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-high-availability)
+* [pod-high-availability](examples/lifecycle/highAvailability.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-high-availability)
 
 Creates a deployment with a replica count of 2 but with no pod anti affinity rules.
 
-* [pod-owner-type](examples/lifecycle/podOwnerType.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-owner-type)
+* [pod-owner-type](examples/lifecycle/podOwnerType.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-owner-type)
 
 Creates a pod with no "owner".  It does not belong to a replicaset or a deployment.
 
-* pod-recreation (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-recreation)
+* pod-recreation (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-recreation)
 
-* pod-scheduling (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-scheduling)
+* pod-scheduling (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-scheduling)
 
-* stateful-scaling (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#statefulset-scaling)
+* stateful-scaling (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#statefulset-scaling)
 
 ### networking
 
-* icmpv4-connectivity (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#icmpv4-connectivity)
+* icmpv4-connectivity (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#icmpv4-connectivity)
 
-* icmpv4-connectivity-multus (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#icmpv4-connectivity-multus)
+* icmpv4-connectivity-multus (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#icmpv4-connectivity-multus)
 
-* [service-type (nodeport check)](examples/networking/nodeport.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#service-type)
+* [service-type (nodeport check)](examples/networking/nodeport.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#service-type)
 
 Creates a service in the cluster that uses type nodePort.  The test suite ensures that no services with nodePort are created.
 
 ### observability
 
-* [container-logging](examples/observability/logging.yaml) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#container-logging)
+* [container-logging](examples/observability/logging.yaml) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#container-logging)
 
 Creates an `echo-server` pod which does some logging to the stdout.  The test checks if stdout is available to pass.  This is sort of an anti-test.  Any pod created that doesn't log to stdout/stderr would fail.
 
-* crd-status (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#crd-status)
+* crd-status (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#crd-status)
 
 ### operator
 
-* install-source (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#install-source)
-* install-status (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#install-status)
+* install-source (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#install-source)
+* install-status (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#install-status)
 
 ### platform-alteration
 
-* base-image (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#base-image)
-* boot-params (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#boot-params)
-* hugepages-config (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#hugepages-config)
-* isredhat-release (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#isredhat-release)
-* sysctl-config (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#sysctl-config)
-* tainted-node-kernel (no example) - [Catalog Link](https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#tainted-node-kernel)
+* base-image (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#base-image)
+* boot-params (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#boot-params)
+* hugepages-config (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#hugepages-config)
+* isredhat-release (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#isredhat-release)
+* sysctl-config (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#sysctl-config)
+* tainted-node-kernel (no example) - [Catalog Link](https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#tainted-node-kernel)

--- a/examples/accesscontrol/serviceAccountTokenPod.yaml
+++ b/examples/accesscontrol/serviceAccountTokenPod.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   # automountServiceAccountToken should be set to false explicitly to satisfy testing requirements.
   # Please visit this link to learn more:
-  # https://github.com/test-network-function/test-network-function/blob/main/CATALOG.md#pod-automount-service-account-token
+  # https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#pod-automount-service-account-token
   automountServiceAccountToken: true
   containers:
     - image: nginx


### PR DESCRIPTION
Changed `test-network-function` to `cnf-certification-test`.  This should have been done a while ago.