### PR TITLE
Remove single worker scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,6 @@ rebuild-cluster: delete-cluster
 	./scripts/delete-standard-storageclass.sh
 	./scripts/remove-control-plane-taint.sh
 
-# Creates a k8s cluster with a single worker
-rebuild-cluster-single-worker: delete-cluster
-	./scripts/deploy-k8s-cluster-single-worker.sh
-	./scripts/preload-images.sh
-	./scripts/deploy-calico.sh
-	./scripts/delete-standard-storageclass.sh
-	./scripts/remove-control-plane-taint.sh
-
 delete-cluster:
 	./scripts/delete-k8s-cluster.sh
 

--- a/scripts/deploy-k8s-cluster-single-worker.sh
+++ b/scripts/deploy-k8s-cluster-single-worker.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -x
-
-# Kind base with kindnetcni and ipv4/ipv6
-kind create cluster --config=config/k8s-cluster/single-worker.yaml


### PR DESCRIPTION
`rebuild-cluster-single-worker` is unused and can be removed.