### PR TITLE
Fix setup-go

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -65,7 +65,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ./testapp/go.mod
 

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ./testapp/go.mod
 
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ./testapp/go.mod
 

--- a/testapp/go.mod
+++ b/testapp/go.mod
@@ -1,3 +1,3 @@
 module main
 
-go 1.24
+go 1.25


### PR DESCRIPTION
This pull request updates the Go version used in the project from 1.24 to 1.25 and ensures that all relevant GitHub Actions workflows use the latest version of the Go setup action. These changes help keep the development environment up-to-date and compatible with the latest Go features and improvements.

Go version update:

* Updated the Go version in `testapp/go.mod` from 1.24 to 1.25 to use the latest Go release.

CI/CD workflow maintenance:

* Updated the `actions/setup-go` action from `v5` to `v6` in `.github/workflows/pre-main.yml` to ensure compatibility with Go 1.25.
* Updated the `actions/setup-go` action from `v5` to `v6` in two places in `.github/workflows/preflight.yml` for consistency and to support Go 1.25. [[1]](diffhunk://#diff-89071218d0bf4bbf9194aad11c0ea2ad7622faa3cf12f8bdf4b4e2225b401a47L19-R19) [[2]](diffhunk://#diff-89071218d0bf4bbf9194aad11c0ea2ad7622faa3cf12f8bdf4b4e2225b401a47L60-R60)