### PR TITLE
Fix preflight HasNoProhibitedLabels for debug-partner image

### DIFF
--- a/.github/workflows/debug-partner-image.yaml
+++ b/.github/workflows/debug-partner-image.yaml
@@ -71,6 +71,8 @@ jobs:
             org.opencontainers.image.title=Debug Partner
             org.opencontainers.image.description=CNF Certification Test uses it.
             org.opencontainers.image.vendor=certsuite
+            name=debug-partner
+            vendor=certsuite
           tags: |
             type=raw,value=latest
             type=schedule,pattern=nightly


### PR DESCRIPTION
Similar to #553 where we fixed the sample-workload image.  The debug-partner image is also failing preflight: https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/actions/runs/17536886086/job/49801557568