### PR TITLE
Update operator-sdk from v1.41.1 to v1.42.2

### DIFF
--- a/scripts/deploy-cr-scale-operator.sh
+++ b/scripts/deploy-cr-scale-operator.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR"/logging.sh
 CR_SCALE_OPERATOR_GIT_REPO="https://github.com/test-network-function/cr-scale-operator.git"
 TAG="main"
 IMG="quay.io/testnetworkfunction/cr-scale-operator:latest"
-KUBE_RBAC_PROXY_IMG="gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1"
+KUBE_RBAC_PROXY_IMG="quay.io/redhat-best-practices-for-k8s/kube-rbac-proxy:v0.13.1"
 CR_SCALE_OPERATOR_DIR=cr-scale-operator
 
 # Clone the repo.

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -16,7 +16,7 @@ else
 	export ARCH OS
 
 	## Download executable
-	export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.41.1
+	export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.42.2
 	curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_"${OS}"_"${ARCH}"
 
 	## Download the auth key


### PR DESCRIPTION
## Summary
- Updates operator-sdk from v1.41.1 to v1.42.2 in scripts/install-operator-sdk.sh
- v1.42.2 is a maintenance release with gRPC dependency bump (1.78.0 → 1.79.3) and Ansible plugin sync
- Release: https://github.com/operator-framework/operator-sdk/releases/tag/v1.42.2

Companion PR: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3563

Ref: CNFCERT-1387