### PR TITLE
Add util-linux to sample workload image

### DIFF
--- a/test-partner/Dockerfile
+++ b/test-partner/Dockerfile
@@ -22,6 +22,7 @@ RUN \
 		openssh-clients \
 		podman \
 		psmisc \
+		util-linux \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \
 	&& rm -rf /var/cache/yum
 


### PR DESCRIPTION
## Summary
- Adds `util-linux` package to the standard sample workload Dockerfile
- This provides `chrt`, which the QE performance tests need to detect scheduling policy on test pods before running certsuite
- Without it, the `shared-cpu-pool-non-rt-scheduling-policy` QE test fails with exit code 255 when attempting `chrt -p 1`

## Test plan
- [ ] Verify the image builds successfully on both amd64 and arm64
- [ ] Verify `chrt` is available inside a running container: `chrt -p 1`
- [ ] Confirm image size increase is minimal