### PR TITLE
Update Go version to 1.26.3 to fix preflight CI

### DIFF
--- a/testapp/go.mod
+++ b/testapp/go.mod
@@ -1,3 +1,3 @@
 module main
 
-go 1.26.1
+go 1.26.3


### PR DESCRIPTION
## Summary
- Bumps Go version in `testapp/go.mod` from 1.26.1 to 1.26.3
- The `openshift-preflight` dependency now requires go >= 1.26.3, and the preflight workflow sets `GOTOOLCHAIN=local`, so the version installed via `setup-go` must satisfy all downstream dependencies

## Test plan
- [ ] Preflight workflow jobs pass (both `preflight-debug-partner` and `preflight-certsuite-sample-workload`)